### PR TITLE
Add host acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Set up the latest version of [HAProxy](http://www.haproxy.org/) in Ubuntu system
 * `haproxy_frontend.{n}.rspadd`: [optional]: Adds headers at the end of the HTTP response
 * `haproxy_frontend.{n}.rspadd.{n}.string`: [required]: The complete line to be added. Any space or known delimiter must be escaped using a backslash (`'\'`)
 * `haproxy_frontend.{n}.rspadd.{n}.cond`: [optional]: A matching condition built from ACLs
+* `haproxy_frontend.{n}.acls`: [optional]: List of ACLs to determine which backend to send.  Currently supports host based only
+* `haproxy_frontend.{n}.acls.{n}.name`: [required]: Name given to the ACL
+* `haproxy_frontend.{n}.acls.{n}.host`: [required]: Servername eg. something.example.com
+* `haproxy_frontend.{n}.acls.{n}.backend`: [required]: Name of the backend to send to
 
 * `haproxy_backend`: [default: `[]`]: Back-end declarations
 * `haproxy_backend.{n}.name`: [required]: The name of the section (e.g. `webservers`)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ boxes = [
 ]
 
 Vagrant.configure("2") do |config|
+  config.ssh.insert_key = false
   boxes.each do |box|
     config.vm.define box[:name] do |vms|
       vms.vm.box = box[:box]

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -30,6 +30,14 @@ frontend {{ frontend.name }}
 {% endfor %}
 {% endif %}
 
+{% if frontend.acls is defined %}
+{% for acl in frontend.acls %}
+  acl host_{{acl.name}} hdr(host) -i {{acl.host}}
+  use_backend {{acl.backend}} if host_{{acl.name}}
+{% endfor %}
+{% endif %}
+
+
   default_backend {{ frontend.default_backend }}
 
 {% if frontend.rspadd is defined %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,8 @@
 # test file for haproxy
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: ubuntu
+  remote_user: vagrant
+  sudo: yes
   roles:
     - ../../
   vars:
@@ -11,10 +12,19 @@
         bind: '0.0.0.0:80'
         mode: http
         default_backend: webservers
+        acls:
+          - { name: alt, host: alt.lvh.me, backend: alternative }
 
     # back-end section
     haproxy_backend:
       - name: webservers
+        mode: http
+        balance: roundrobin
+        option:
+          - forwardfor
+          - 'httpchk HEAD / HTTP/1.1\r\nHost:localhost'
+        server: []
+      - name: alternative
         mode: http
         balance: roundrobin
         option:

--- a/tests/vagrant
+++ b/tests/vagrant
@@ -1,0 +1,8 @@
+[ubuntu]
+ubuntu-1004 ansible_ssh_host=10.0.0.10
+ubuntu-1204 ansible_ssh_host=10.0.0.11
+ubuntu-1404 ansible_ssh_host=10.0.0.12
+
+[ubuntu:vars]
+ansible_ssh_user=vagrant
+ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
@tersmitten I want to be able to use haproxy for host-based load balancing, so this adds the needed details to the frontend template

Could also have path_beg and path_end ACLs, but I don't use those at this time.

Also added a static vagrant inventory, since I like running ansible-playbooks against vagrant from outside for more reliable results.  Its more convenient to not have the Vagrantfile override the insecure_key in that case.  Over to you if you're happy with it.
