### PR TITLE
Add ability to add http-response statements to `listen`, `frontend` and `backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.http_request.{n}.action`: [required]: The rules action (e.g. `add-header`)
 * `haproxy_listen.{n}.http_request.{n}.param`: [optional]: The complete line to be added (e.g. `X-Forwarded-Proto https`)
 * `haproxy_listen.{n}.http_request.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
+* `haproxy_listen.{n}.http_response`: [optional]: Access control for Layer 7 responses
+* `haproxy_listen.{n}.http_response.{n}.action`: [required]: The rules action (e.g. `del-header`)
+* `haproxy_listen.{n}.http_response.{n}.param`: [optional]: The complete line to be added (e.g. `X-Varnish`)
+* `haproxy_listen.{n}.http_response.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
 * `haproxy_listen.{n}.stats`: [optional]: Stats declarations
 * `haproxy_listen.{n}.stats.enable`: [required]: Enables statistics reporting with default settings
 * `haproxy_listen.{n}.stats.uri`: [optional, default `/`]: Define the URI prefix to access statistics
@@ -113,6 +117,10 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_frontend.{n}.http_request.{n}.action`: [required]: The rules action (e.g. `add-header`)
 * `haproxy_frontend.{n}.http_request.{n}.param`: [optional]: The complete line to be added (e.g. `X-Forwarded-Proto https`)
 * `haproxy_frontend.{n}.http_request.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
+* `haproxy_frontend.{n}.http_response`: [optional]: Access control for Layer 7 responses
+* `haproxy_frontend.{n}.http_response.{n}.action`: [required]: The rules action (e.g. `del-header`)
+* `haproxy_frontend.{n}.http_response.{n}.param`: [optional]: The complete line to be added (e.g. `X-Varnish`)
+* `haproxy_frontend.{n}.http_response.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
 * `haproxy_frontend.{n}.default_backend`: [required]: The backend to use when no `"use_backend"` rule has been matched (e.g. `webservers`)
 * `haproxy_frontend.{n}.rspadd`: [optional]: Adds headers at the end of the HTTP response
 * `haproxy_frontend.{n}.rspadd.{n}.string`: [required]: The complete line to be added. Any space or known delimiter must be escaped using a backslash (`'\'`) (in version < 1.6)
@@ -137,6 +145,10 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_backend.{n}.http_request.{n}.action`: [required]: The rules action (e.g. `add-header`)
 * `haproxy_backend.{n}.http_request.{n}.param`: [optional]: The complete line to be added (e.g. `X-Forwarded-Proto https`)
 * `haproxy_backend.{n}.http_request.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
+* `haproxy_backend.{n}.http_response`: [optional]: Access control for Layer 7 responses
+* `haproxy_backend.{n}.http_response.{n}.action`: [required]: The rules action (e.g. `del-header`)
+* `haproxy_backend.{n}.http_response.{n}.param`: [optional]: The complete line to be added (e.g. `X-Varnish`)
+* `haproxy_backend.{n}.http_response.{n}.cond`: [optional]: A matching condition built from ACLs (e.g. `if { ssl_fc }`)
 * `haproxy_backend.{n}.server`: [optional]: Server declarations
 * `haproxy_backend.{n}.server.{n}.name`: [required]: The internal name assigned to this server
 * `haproxy_backend.{n}.server.{n}.listen`: [required]: Defines a listening address and/or ports

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -33,6 +33,11 @@ backend {{ backend.name }}
 
 {% endfor %}
 
+{% for http_response in backend.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
+
+{% endfor %}
+
 {% for server in backend.server | default([]) %}
   server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
 

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -36,6 +36,11 @@ frontend {{ frontend.name }}
 
 {% endfor %}
 
+{% for http_response in frontend.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
+
+{% endfor %}
+
 {% for rspadd in frontend.rspadd | default([]) %}
   rspadd {{ rspadd.string }}{% if rspadd.cond is defined %} {{ rspadd.cond }}{% endif %}
 

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -61,6 +61,11 @@ listen {{ listen.name }}
 
 {% endfor %}
 
+{% for http_response in listen.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
+
+{% endfor %}
+
 {% for rspadd in listen.rspadd | default([]) %}
   rspadd {{ rspadd.string }}{% if rspadd.cond is defined %} {{ rspadd.cond }}{% endif %}
 


### PR DESCRIPTION
It is already possible to add statements for `http-request`, so statements for `http-response` should be available as well.

Also (from http://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4-http-response):

> Using "rspadd"/"rspdel"/"rsprep" to manipulate request headers is discouraged in newer versions (>= 1.5). But if you need to use regular expression to delete headers, you can still use "rspdel". Also please use "http-response deny" instead of "rspdeny".