### PR TITLE
add preliminary Red Hat platform support

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
   service:
     name: haproxy
     state: restarted
+
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,31 @@
+
+
+
+- name: add repository from PPA and install its signing key
+  apt_repository:
+    repo: "{{ haproxy_ppa }}"
+    update_cache: true
+  tags:
+  - configuration
+  - haproxy
+  - haproxy-add-repository
+
+- name: install dependencies
+  apt:
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+  with_items: "{{ haproxy_dependencies }}"
+  tags:
+  - configuration
+  - haproxy
+  - haproxy-dependencies
+
+- name: install
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ haproxy_install }}"
+  tags:
+  - configuration
+  - haproxy
+  - haproxy-install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,34 +9,13 @@
     - haproxy
     - haproxy-check-version-support
 
-- name: add repository from PPA and install its signing key
-  apt_repository:
-    repo: "{{ haproxy_ppa }}"
-    update_cache: true
-  tags:
-    - configuration
-    - haproxy
-    - haproxy-add-repository
+- name: run debian setup
+  include: debian.yml
+  when: ansible_os_family == "Debian"
 
-- name: install dependencies
-  apt:
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ haproxy_dependencies }}"
-  tags:
-    - configuration
-    - haproxy
-    - haproxy-dependencies
-
-- name: install
-  apt:
-    name: "{{ item }}"
-    state: latest
-  with_items: "{{ haproxy_install }}"
-  tags:
-    - configuration
-    - haproxy
-    - haproxy-install
+- name: run redhat setup
+  include: redhat.yml
+  when: ansible_os_family == "RedHat"
 
 - name: create certificate files directories
   file:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,25 @@
+
+# leave setting up of repos to use to external play / environment setup
+
+- name: install dependencies
+  yum:
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+  with_items: "{{ haproxy_dependencies }}"
+  tags:
+  - configuration
+  - haproxy
+  - haproxy-dependencies
+
+- name: install
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ haproxy_install }}"
+  tags:
+  - configuration
+  - haproxy
+  - haproxy-install
+  notify:
+  - reload systemd
+


### PR DESCRIPTION
- split out installation tasks into platform specific task files
- omit repo setup.  Leave this up to the environment owners to ensure
  access to software is supplied.  Should be available on later RHEL6+

Still needs:
- test suite
- testing
- doc updates
