### PR TITLE
Add support for dynamic backend servers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,11 @@ haproxy_dependencies:
     state: latest
 haproxy_install: []
 
+# A list of groups that will be searched during dynamic backend discovery
+haproxy_backend_search: yes
+haproxy_backend_search_group: all
+haproxy_backend_search_var: haproxy_backend_member
+
 # global section
 haproxy_global_log:
   - address: /dev/log

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -60,4 +60,18 @@ backend {{ backend.name }}
 
 {% endfor %}
 
+{# Build a list of hosts to search for backends inside their hostvars
+   This can be done much more efficiently using map/extract once Ansible<2.2
+   support is dropped #}
+{% if haproxy_backend_search | bool %}
+{%   for host in groups[haproxy_backend_search_group] %}
+{%     if hostvars[host][haproxy_backend_search_var] is defined and
+          hostvars[host][haproxy_backend_search_var][backend.name] is defined %}
+{%       set _server = hostvars[host][haproxy_backend_search_var][backend.name] %}
+  server {{ _server.name }} {{ _server.listen }} {{ _server.param | default([]) | join(' ') }}
+
+{%     endif %}
+{%   endfor %}
+{% endif %}
+
 {% endfor %}


### PR DESCRIPTION
Read from hostvars to dynamically allocate hosts to a given backend.

Define haproxy_frontend, haproxy_backend as per normal in the load
balancer group_vars. Do not need to define any 'server' list on the
mariadb-back backend. Instead, define in your mariadb node group_vars:

From ex. group_vars/mariadb.yml:
```yaml
haproxy_backend_member:
  'mariadb-back':
    name: "{{ inventory_hostname }}"
    listen: "{{ ansible_host }}:3306"
    param:
      - 'check port 3306'
      - 'rise 2'
      - 'fall 2'
```

This will add a 'server' entry under the 'mariadb-back' backend for
each host in the mariadb group.