### PR TITLE
Add support for configuring proxy source IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 
 * `haproxy_defaults_log`: [default: `global`]: Enable per-instance logging of events and traffic. `global` should be used when the instance's logging parameters are the same as the global ones. This is the most common usage
 * `haproxy_defaults_mode`: [default: `http`]: Set the running mode or protocol of the instance
+* `haproxy_defaults_source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_defaults_option`: [default: `[httplog, dontlognull]`]: Options (default)
 * `haproxy_defaults_timeout`: [default: See `defaults/main.yml`]: Timeout declarations
 * `haproxy_defaults_timeout.type`: [required]: The type (e.g. `connect`, `client`, `server`)
@@ -69,6 +70,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.mode`: [required]: Set the running mode or protocol of the section (e.g. `http`)
 * `haproxy_listen.{n}.balance`: [required]: The load balancing algorithm to be used (e.g. `roundrobin`)
 * `haproxy_listen.{n}.maxconn`: [optional]: Fix the maximum number of concurrent connections
+* `haproxy_listen.{n}.source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_listen.{n}.option`: [optional]: Options to set (e.g. `[dontlog-normal]`)
 * `haproxy_listen.{n}.no_option`: [optional]: Options to set (e.g. `[dontlog-normal]`)
 * `haproxy_listen.{n}.tcp_check`: [optional]: Perform health checks using tcp-check send/expect sequences (e.g. `['expect string +OK\ POP3\ ready']`)
@@ -158,6 +160,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_backend.{n}.bind_process`:  [optional]: Limits the declaration to a certain set of processes numbers (e.g. `[all]`, `[1]`, `[2 ,3, 4]`)
 * `haproxy_backend.{n}.mode`: [required]: Set the running mode or protocol of the section (e.g. `http`)
 * `haproxy_backend.{n}.balance`: [required]: The load balancing algorithm to be used (e.g. `roundrobin`)
+* `haproxy_backend.{n}.source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_backend.{n}.option`: [optional]: Options to set (e.g. `[forwardfor]`)
 * `haproxy_backend.{n}.no_option`: [optional]: Options to unset (e.g. `[forceclose]`)
 * `haproxy_backend.{n}.tcp_check`: [optional]: Perform health checks using tcp-check send/expect sequences (e.g. `['expect string +OK\ POP3\ ready']`)

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -12,6 +12,10 @@ backend {{ backend.name }}
 
   balance {{ backend.balance }}
 
+{% if backend.source is defined %}
+  source {{ backend.source }}
+{% endif %}
+
 {% for option in backend.option | default([])%}
   option {{ option }}
 {% endfor %}

--- a/templates/etc/haproxy/defaults.cfg.j2
+++ b/templates/etc/haproxy/defaults.cfg.j2
@@ -6,6 +6,10 @@
   mode {{ haproxy_defaults_mode }}
 {% endif %}
 
+{% if haproxy_defaults_source is defined %}
+  source {{ haproxy_defaults_source }}
+{% endif %}
+
 {% if haproxy_defaults_option != false %}
 {% for option in haproxy_defaults_option %}
   option {{ option }}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -23,6 +23,10 @@ listen {{ listen.name }}
   maxconn {{ listen.maxconn }}
 {% endif %}
 
+{% if listen.source is defined %}
+  source {{ listen.source }}
+{% endif %}
+
 {% for option in listen.option | default([]) %}
   option {{ option }}
 {% endfor %}


### PR DESCRIPTION
Allow configuration of the proxy outbound connection source IP
or interface per the docs at:

https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#4-source