### PR TITLE
Fix chroot in global template

### DIFF
--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -8,7 +8,7 @@
 {% endfor %}
 {% endif %}
 
-{% if haproxy_global_chroot | bool != false %}
+{% if haproxy_global_chroot.tolower() != 'false' %}
   chroot {{ haproxy_global_chroot }}
 {% endif %}
 

--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -8,7 +8,7 @@
 {% endfor %}
 {% endif %}
 
-{% if haproxy_global_chroot.tolower() != 'false' %}
+{% if haproxy_global_chroot.lower() != 'false' %}
   chroot {{ haproxy_global_chroot }}
 {% endif %}
 


### PR DESCRIPTION
bool filter returns False unless the string is 'yes', 'on', '1', 'true', 1 (which a path isn't).
https://dddpaul.github.io/blog/2015/11/30/ansible-default-and-bool-filters/

Doing a simple string comparison instead seems to work.