### PR TITLE
Added support for conf.d like configuration handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 sudo: required
 dist: trusty
+group: deprecated-2017Q2
 
 language: python
 python: "2.7"

--- a/Vagrantfile.full
+++ b/Vagrantfile.full
@@ -1,0 +1,105 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby ts=2 sw=2 tw=0 et :
+
+role = File.basename(File.expand_path(File.dirname(__FILE__)))
+
+ansible_versions = [
+  'latest',
+  '2.3.1.0',
+  '2.3.0.0',
+  '2.2.3.0',
+  '2.2.2.0',
+  '2.2.1.0',
+  '2.2.0.0',
+  '2.1.6',
+  '2.1.5',
+  '2.1.4',
+  '2.1.3',
+  '2.1.2',
+  '2.1.1.0',
+  '2.1.0.0',
+  '2.0.2.0',
+  '2.0.1.0',
+  '2.0.0.2',
+  '2.0.0.1',
+  '2.0.0.0',
+  '1.9.6',
+]
+
+os_versions = [
+  {
+    :name => "ubuntu-1204",
+    :box => "bento/ubuntu-12.04",
+  },
+  {
+    :name => "ubuntu-1404",
+    :box => "bento/ubuntu-14.04",
+  },
+  {
+    :name => "ubuntu-1604",
+    :box => "bento/ubuntu-16.04",
+  },
+]
+
+boxes = []
+
+ip = 5
+os_versions.each do |os|
+  ansible_versions.reverse.each do |v|
+    boxes << {
+        :name => "ansible-#{v}-#{os[:name]}",
+        :box => os[:box],
+        :ip => "10.0.0.#{ip}",
+        :ansible_version => v
+      }
+      ip += 1
+  end
+end
+
+Vagrant.configure("2") do |config|
+  boxes.each do |box|
+    config.vm.define box[:name] do |vms|
+      vms.vm.box = box[:box]
+
+      if Vagrant.has_plugin?("vagrant-cachier")
+        # Configure cached packages to be shared between instances of the same base box.
+        # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+        vms.cache.scope = :box
+      end
+
+      vms.vm.hostname = box[:name]
+
+      vms.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--cpuexecutioncap", "90"]
+        v.linked_clone = true
+        v.memory = 256
+        v.cpus = 2
+      end
+
+      vms.vm.network :private_network, ip: box[:ip]
+
+      vms.vm.provision "shell",
+        inline: "apt-get -qq -y install wget"
+
+      vms.vm.provision "ansible_local" do |ansible|
+        ansible.version = box[:ansible_version]
+        ansible.install_mode = "pip"
+        ansible.playbook = "tests/vagrant.yml"
+      end
+
+      # tests ported from travis
+      vms.vm.provision "shell",
+        inline: 'ansible-playbook -i /vagrant/tests/inventory /vagrant/tests/test.yml --syntax-check'
+
+      vms.vm.provision "shell",
+        inline: "ansible-playbook -i /vagrant/tests/inventory /vagrant/tests/test.yml -vvvv"
+
+      vms.vm.provision "shell",
+        inline: "ansible-playbook -i /vagrant/tests/inventory /vagrant/tests/test.yml | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+
+      vms.vm.provision "shell",
+        inline: "wget http://localhost -O /dev/null -S --quiet 2>&1 | grep -q '503 Service Unavailable' && (echo 'Availability test: pass' && exit 0) || (echo 'Availability test: fail' && exit 1)"
+
+    end
+  end
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,3 +70,6 @@ haproxy_frontend: []
 
 # back-end section
 haproxy_backend: []
+
+# conf.d location
+haproxy_cfg_path: /etc/haproxy/conf.d

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,15 +67,53 @@
     - haproxy-configuration
     - haproxy-configuration-ssl
 
+- name: create configuration folder
+  file:
+    path: "{{ haproxy_cfg_path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0750
+  tags:
+    - configuration
+    - haproxy
+    - haproxy-configuration
+
 - name: update configuration file
   template:
     src: etc/haproxy/haproxy.cfg.j2
-    dest: /etc/haproxy/haproxy.cfg
+    dest: "{{ haproxy_main_cfg_part }}"
     owner: root
     group: root
     mode: 0640
-    validate: 'haproxy -f %s -c'
+    validate: "{{ haproxy_validation_command }}"
   notify: restart haproxy
+  tags:
+    - configuration
+    - haproxy
+    - haproxy-configuration
+
+- name: assemble haproxy
+  assemble:
+    ignore_hidden: true
+    src: "{{ haproxy_cfg_path }}"
+    dest: "{{ haproxy_main_cfg }}"
+    delimiter: "### START FRAGMENT ###"
+    validate: "{{ haproxy_validation_command }}"
+  notify: restart haproxy
+  when: ansible_version | version_compare('2.0', '>=')
+  tags:
+    - configuration
+    - haproxy
+    - haproxy-configuration
+
+- name: assemble haproxy (ansible_version < 2.0)
+  assemble:
+    src: "{{ haproxy_cfg_path }}"
+    dest: "{{ haproxy_main_cfg }}"
+    delimiter: "### START FRAGMENT ###"
+  notify: restart haproxy
+  when: ansible_version | version_compare('2.0', '<')
   tags:
     - configuration
     - haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,7 +101,7 @@
     delimiter: "### START FRAGMENT ###"
     validate: "{{ haproxy_validation_command }}"
   notify: restart haproxy
-  when: ansible_version | version_compare('2.0', '>=')
+  when: ansible_version.full | version_compare('2.0', 'ge')
   tags:
     - configuration
     - haproxy
@@ -113,7 +113,7 @@
     dest: "{{ haproxy_main_cfg }}"
     delimiter: "### START FRAGMENT ###"
   notify: restart haproxy
-  when: ansible_version | version_compare('2.0', '<')
+  when: ansible_version.full | version_compare('2.0', 'lt')
   tags:
     - configuration
     - haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,7 +93,7 @@
     - haproxy
     - haproxy-configuration
 
-- name: assemble haproxy
+- name: assemble haproxy configuration file
   assemble:
     ignore_hidden: true
     src: "{{ haproxy_cfg_path }}"
@@ -107,7 +107,7 @@
     - haproxy
     - haproxy-configuration
 
-- name: assemble haproxy (ansible_version < 2.0)
+- name: assemble haproxy configuration file (ansible < 2.0)
   assemble:
     src: "{{ haproxy_cfg_path }}"
     dest: "{{ haproxy_main_cfg }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,6 @@ haproxy_versions_supported:
 
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 
-haproxy_cfg_path: /etc/haproxy/conf.d
-haproxy_main_cfg_part: /etc/haproxy/conf.d/00-haproxy.cfg
+haproxy_main_cfg_part: "{{ haproxy_cfg_path }}/00-haproxy.cfg"
 haproxy_main_cfg: /etc/haproxy/haproxy.cfg
 haproxy_validation_command: 'haproxy -f %s -c'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ haproxy_versions_supported:
 
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 
-haproxy_cfg_path:  /etc/haproxy/conf.d
-haproxy_main_cfg_part:  /etc/haproxy/conf.d/00-haproxy.cfg
-haproxy_main_cfg:  /etc/haproxy/haproxy.cfg
+haproxy_cfg_path: /etc/haproxy/conf.d
+haproxy_main_cfg_part: /etc/haproxy/conf.d/00-haproxy.cfg
+haproxy_main_cfg: /etc/haproxy/haproxy.cfg
 haproxy_validation_command: 'haproxy -f %s -c'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,8 @@ haproxy_versions_supported:
   - 1.7
 
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
+
+haproxy_cfg_path:  /etc/haproxy/conf.d
+haproxy_main_cfg_part:  /etc/haproxy/conf.d/00-haproxy.cfg
+haproxy_main_cfg:  /etc/haproxy/haproxy.cfg
+haproxy_validation_command: 'haproxy -f %s -c'


### PR DESCRIPTION
- Instead of managing just one `haproxy.cfg` file with this final configuration file will be assembled from all files residing inside of `haproxy_cfg_path`.
It will give users option to add own files into the main configuration for cases which are not covered with standard configuration options in the role, i.e. generated frontend/backend lists from external sources.
- Moved few hardcoded paths into variables.
- Added a fix to the .travis.yml so it can work again with latest trusty image changes.
- Created additional `Vagrantfile` which can be used to test any distro / ansible version combination instead waiting for Travis to complain.