### PR TITLE
Add stats capability to backend template

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_backend.{n}.http_response.{n}.action`: [required]: The rules action (e.g. `del-header`)
 * `haproxy_backend.{n}.http_response.{n}.param`: [optional]: The complete line to be added (e.g. `X-Varnish`)
 * `haproxy_backend.{n}.http_response.{n}.cond`: [optional]: A matching condition built from ACLs
+* `haproxy_backend.{n}.stats`: [optional]: Stats declarations
+* `haproxy_backend.{n}.stats.enable`: [required]: Enables statistics reporting with default settings
+* `haproxy_backend.{n}.stats.uri`: [optional, default `/`]: Define the URI prefix to access statistics
+* `haproxy_backend.{n}.stats.options`: [optional]: List of boolean stats options (e.g. `hide-version`, `show-node`, `show-desc`, `show-legends`)
+* `haproxy_backend.{n}.stats.refresh`: [optional]: Defined the refresh delay, specified in seconds (e.g. `5s`)
+* `haproxy_backend.{n}.stats.admin`: [optional]: Define / enable admin part of web interface with conditional attached
+* `haproxy_backend.{n}.stats.auth`: [optional]: Auth declarations
+* `haproxy_backend.{n}.stats.auth.{n}.user`: [required]: A user name to grant access to
+* `haproxy_backend.{n}.stats.auth.{n}.passwd`: [required]: The cleartext password associated to this user
 * `haproxy_backend.{n}.compression`: [optional]: Compression declarations
 * `haproxy_backend.{n}.compression.{n}.name`: [required]: The compression name (e.g. `algo`, `type`, `offload`)
 * `haproxy_backend.{n}.compression.{n}.value`: [required]: The compression value, (e.g. if name = algo : one of this values `identity`, `gzip`, `deflate`, `raw-deflate` / if name = type : list of mime type separated by space for example `text/html text/plain text/css` / if name = `offload` value is empty)

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -45,6 +45,26 @@ backend {{ backend.name }}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
 
+{% if backend.stats is defined %}
+{% if backend.stats.enable is defined and backend.stats.enable | bool == true %}
+  stats enable
+  stats uri {{ backend.stats.uri | default('/') }}
+{% if backend.stats.refresh is defined %}
+  stats refresh {{ backend.stats.refresh }}
+{% endif %}
+{% if backend.stats.admin is defined %}
+  stats admin {{ backend.stats.admin }}
+{% endif %}
+{% for option in backend.stats.options | default([]) %}
+  stats {{ option }}
+{% endfor %}
+{% for auth in backend.stats.auth | default([]) %}
+  stats auth {{ auth.user }}:{{ auth.passwd }}
+
+{% endfor %}
+{% endif %}
+{% endif %}
+
 {% for http_request in backend.http_request | default([]) %}
   http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
 


### PR DESCRIPTION
Pretty straight forward, the stats parameters that can be defined on listen and frontend are also supported on backend definitions by haproxy, however they were not present in the backend template. This just copies them from the listen template and docs.