### PR TITLE
Dynamic raw config options rendering

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,3 +70,36 @@ haproxy_frontend: []
 
 # back-end section
 haproxy_backend: []
+
+# Keys that are rendered as verbatim strings to the haproxy configuration.
+# A "key" is the dictionary key on the haproxy_{frontend,backend,listen} list,
+# and list_accepted is defaulted to "yes". When there is a list accepted, the
+# option can be provided as either a string or a list of strings to be
+# outputted multiple times to the configuration.
+haproxy_raw_keys:
+  - key: description
+    list_accepted: no
+  - key: mode
+    list_accepted: no
+  - key: maxconn
+    list_accepted: no
+  - key: balance
+    list_accepted: no
+  - key: source
+    list_accepted: no
+  - key: option
+  - key: no_option
+    config_key: 'no option'
+  - key: http_check
+    config_key: 'http-check'
+    list_accepted: no
+  - key: cookie
+    list_accepted: no
+  - key: tcp_check
+    config_key: 'tcp-check'
+  - key: acl
+  - key: reqrep
+  - key: reqirep
+  - key: use_backend
+  - key: default_backend
+    list_accepted: no

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -1,44 +1,27 @@
 {% for backend in haproxy_backend %}
 backend {{ backend.name }}
-{% if backend.description is defined %}
-  description {{ backend.description }}
-{% endif %}
+{% for item in haproxy_raw_keys %}
+{%   if backend[item['key']] is defined %}
+{%     if item['list_accepted'] | default('yes') | bool and
+          backend[item['key']] is iterable and
+          backend[item['key']] is not string %}
+{%       for option in backend[item['key']] %}
+  {{ item['config_key'] | default(item['key']) }} {{ option }}
+{%       endfor %}
+{%     else %}
+  {{ item['config_key'] | default(item['key']) }} {{ backend[item['key']] }}
+{%     endif %}
+{%   endif %}
+
+{% endfor %}
 
 {% if backend.bind_process is defined %}
   bind-process {{ backend.bind_process | join(' ') }}
 {% endif %}
 
-  mode {{ backend.mode }}
-
-  balance {{ backend.balance }}
-
-{% if backend.source is defined %}
-  source {{ backend.source }}
-{% endif %}
-
-{% for option in backend.option | default([])%}
-  option {{ option }}
-{% endfor %}
-
-{% if backend.http_check is defined %}
-  http-check {{ backend.http_check }}
-{% endif %}
-
-{% if backend.cookie is defined %}
-  cookie {{ backend.cookie }}
-{% endif %}
-
 {% for stick in backend.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}
-{% endfor %}
-
-{% for option in backend.no_option | default([]) %}
-  no option {{ option }}
-{% endfor %}
-
-{% for tcp_check in backend.tcp_check | default([]) %}
-  tcp-check {{ tcp_check }}
 {% endfor %}
 
 {% for timeout in backend.timeout | default([]) %}

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -1,8 +1,19 @@
 {% for frontend in haproxy_frontend %}
 frontend {{ frontend.name }}
-{% if frontend.description is defined %}
-  description {{ frontend.description }}
-{% endif %}
+{% for item in haproxy_raw_keys %}
+{%   if frontend[item['key']] is defined %}
+{%     if item['list_accepted'] | default('yes') | bool and
+          frontend[item['key']] is iterable and
+          frontend[item['key']] is not string %}
+{%       for option in frontend[item['key']] %}
+  {{ item['config_key'] | default(item['key']) }} {{ option }}
+{%       endfor %}
+{%     else %}
+  {{ item['config_key'] | default(item['key']) }} {{ frontend[item['key']] }}
+{%     endif %}
+{%   endif %}
+
+{% endfor %}
 
 {% for bind in frontend.bind %}
   bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
@@ -13,31 +24,13 @@ frontend {{ frontend.name }}
   bind-process {{ frontend.bind_process | join(' ') }}
 {% endif %}
 
-  mode {{ frontend.mode }}
-
-{% if frontend.maxconn is defined %}
-  maxconn {{ frontend.maxconn }}
-{% endif %}
-
 {% for stick in frontend.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}
 {% endfor %}
 
-{% for option in frontend.option | default([]) %}
-  option {{ option }}
-{% endfor %}
-
-{% for option in frontend.no_option | default([]) %}
-  no option {{ option }}
-{% endfor %}
-
 {% for timeout in frontend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
-{% endfor %}
-
-{% for acl in frontend.acl | default([]) %}
-  acl {{ acl.string }}
 {% endfor %}
 
 {% for capture in frontend.capture | default([]) %}
@@ -72,17 +65,4 @@ frontend {{ frontend.name }}
 {% for compression in frontend.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
-
-{% if frontend.use_backend is defined %}
-{% if frontend.use_backend is iterable and frontend.use_backend is not string %}
-{% for use_backend in frontend.use_backend | default([]) %}
-  use_backend {{ use_backend }}
-{% endfor %}
-{% else %}
-  use_backend {{ frontend.use_backend }}
-{% endif %}
-{% endif %}
-
-  default_backend {{ frontend.default_backend }}
-
 {% endfor %}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -1,8 +1,19 @@
 {% for listen in haproxy_listen %}
 listen {{ listen.name }}
-{% if listen.description is defined %}
-  description {{ listen.description }}
-{% endif %}
+{% for item in haproxy_raw_keys %}
+{%   if listen[item['key']] is defined %}
+{%     if item['list_accepted'] | default('yes') | bool and
+          listen[item['key']] is iterable and
+          listen[item['key']] is not string %}
+{%       for option in listen[item['key']] %}
+  {{ item['config_key'] | default(item['key']) }} {{ option }}
+{%       endfor %}
+{%     else %}
+  {{ item['config_key'] | default(item['key']) }} {{ listen[item['key']] }}
+{%     endif %}
+{%   endif %}
+
+{% endfor %}
 
 {% for bind in listen.bind %}
   bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
@@ -13,47 +24,13 @@ listen {{ listen.name }}
   bind-process {{ listen.bind_process | join(' ') }}
 {% endif %}
 
-  mode {{ listen.mode }}
-
-{% if listen.balance is defined %}
-  balance {{ listen.balance }}
-{% endif %}
-
-{% if listen.maxconn is defined %}
-  maxconn {{ listen.maxconn }}
-{% endif %}
-
-{% if listen.http_check is defined %}
-  http-check {{ listen.http_check }}
-{% endif %}
-
 {% for stick in listen.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}
 {% endfor %}
 
-{% if listen.source is defined %}
-  source {{ listen.source }}
-{% endif %}
-
-{% for option in listen.option | default([]) %}
-  option {{ option }}
-{% endfor %}
-
-{% for option in listen.no_option | default([])  %}
-  no option {{ option }}
-{% endfor %}
-
-{% for tcp_check in listen.tcp_check | default([]) %}
-  tcp-check {{ tcp_check }}
-{% endfor %}
-
 {% for timeout in listen.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
-{% endfor %}
-
-{% for acl in listen.acl | default([]) %}
-  acl {{ acl.string }}
 {% endfor %}
 
 {% for capture in listen.capture | default([]) %}


### PR DESCRIPTION
Since many of the parameters are rendered directly to the config as
strings, or lists of strings with a common key, it is easy to
consolidate all of the output logic into a single loop that renders
the options from a list of vars.

This has the added benefit for downstream consumers of allowing
them to inject additional config vars into the role and have them
rendered to the haproxy config without requiring a fork and
modification of the role itself.