### PR TITLE
Allow support for `no log` in listen section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.mode`: [required]: Set the running mode or protocol of the section (e.g. `http`)
 * `haproxy_listen.{n}.balance`: [required]: The load balancing algorithm to be used (e.g. `roundrobin`)
 * `haproxy_listen.{n}.maxconn`: [optional]: Fix the maximum number of concurrent connections
+* `haproxy_listen.{n}.nolog`: [optional]: Used when the logger list must be flushed. For example, if you don't want to inherit from the default logger list.
 * `haproxy_listen.{n}.source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_listen.{n}.option`: [optional]: Options to set (e.g. `[dontlog-normal]`)
 * `haproxy_listen.{n}.no_option`: [optional]: Options to set (e.g. `[dontlog-normal]`)

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -19,6 +19,10 @@ listen {{ listen.name }}
   balance {{ listen.balance }}
 {% endif %}
 
+{% if listen.nolog is defined %}
+  no log
+{% endif %}
+
 {% if listen.maxconn is defined %}
   maxconn {{ listen.maxconn }}
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/Oefenweb/ansible-haproxy/issues/40