### PR TITLE
Remove stick on from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_frontend.{n}.maxconn`: [optional]: Fix the maximum number of concurrent connections
 * `haproxy_frontend.{n}.stick`: [optional]: Stick declarations
 * `haproxy_frontend.{n}.stick.{n}.table`: [required]: Configure the stickiness table for the current section (e.g. `type ip size 500k`)
-* `haproxy_frontend.{n}.stick.{n}.stick_on`: [required]: Define a request pattern to associate a user to a server (e.g. `src`)
 * `haproxy_frontend.{n}.option`: [optional]: Options to set (e.g. `[tcplog]`)
 * `haproxy_frontend.{n}.no_option`: [optional]: Options to unset (e.g. `[forceclose]`)
 * `haproxy_frontend.{n}.no_log`: [optional, default `false`]: Used when the logger list must be flushed. For example, if you don't want to inherit from the default logger list

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -21,7 +21,6 @@ frontend {{ frontend.name }}
 
 {% for stick in frontend.stick | default([]) %}
   stick-table {{ stick.table }}
-  stick on {{ stick.stick_on }}
 {% endfor %}
 
 {% for option in frontend.option | default([]) %}


### PR DESCRIPTION
According to [haproxy's doc](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-stick%20on) stick on is not supported under frontend.