### PR TITLE
Add var haproxy_restart_mode used by handler

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ haproxy_dependencies:
     state: latest
 haproxy_install: []
 
+haproxy_restart_mode: restarted
+
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"
 
 # global section

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ haproxy_dependencies:
     state: latest
 haproxy_install: []
 
-haproxy_restart_mode: restarted
+haproxy_restart_handler_state: restarted
 
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart haproxy
   service:
     name: haproxy
-    state: restarted
+    state: "{{ haproxy_reload_mode }}"
   when: service_default_state | default('started') == 'started'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart haproxy
   service:
     name: haproxy
-    state: "{{ haproxy_restart_mode }}"
+    state: "{{ haproxy_restart_handler_state }}"
   when: service_default_state | default('started') == 'started'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart haproxy
   service:
     name: haproxy
-    state: "{{ haproxy_reload_mode }}"
+    state: "{{ haproxy_restart_mode }}"
   when: service_default_state | default('started') == 'started'


### PR DESCRIPTION
Adds the ability to override the default `restarted` state using the `reloaded` state.

Is similar to #60 but it doesn't change the default state 
