### PR TITLE
Service discovery feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.server.{n}.name`: [required]: The internal name assigned to this server
 * `haproxy_listen.{n}.server.{n}.listen`: [required]: Defines a listening address and/or ports
 * `haproxy_listen.{n}.server.{n}.param`: [optional]: A list of parameters for this server
-
 * `haproxy_listen.{n}.server_template`: [optional]: Server template declarations
 * `haproxy_listen.{n}.server_template.{n}.name`: [required]: The internal name assigned to this server
 * `haproxy_listen.{n}.server_template.{n}.number`: [required]: The internal dns records number assigned to this server
@@ -403,6 +402,30 @@ None
             param:
               - 'maxconn 503'
               - check
+
+      - name: webservers-sdns
+        description: Back-end with all (Apache) webservers
+        mode: http
+        balance: roundrobin
+        option:
+          - forwardfor
+          - 'httpchk HEAD / HTTP/1.1\r\nHost:localhost'
+        http_request:
+          - action: 'set-header'
+            param: 'X-Forwarded-Port %[dst_port]'
+          - action: 'add-header'
+            param: 'X-Forwarded-Proto https'
+            cond: 'if { ssl_fc }'
+        server_template:
+          - name: web
+          	number: 3
+            listen: "_http._tcp.web.skydns.local:80"
+            param:
+              - 'resolvers {{ haproxy_resolvers_label }}'
+              - 'maxconn 501'
+              - check
+
+
 ```
 
 #### SSL Termination 2

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_defaults_compression.{}.name`: [required]: The compression name (e.g. `algo`, `type`, `offload`)
 * `haproxy_defaults_compression.{}.value`: [required]: The compression value, (e.g. if name = algo : one of this values `identity`, `gzip`, `deflate`, `raw-deflate` / if name = type : list of mime type separated by space for example `text/html text/plain text/css` / if name = `offload` value is empty)
   
-* `haproxy_resolvers_label`: [default: `[]`]: The global name of your dns resolver
-* `haproxy_resolvers_list.{n}.name`: [required]: The name of the dns resolver
+* `haproxy_resolverslist`: [default: `[]`]: The global name of your dns resolver
+* `haproxy_resolvers_list.{n}.id`: [required]: The name of the dns resolver
 * `haproxy_resolvers_list.{n}.listen`: [required]: The location of your dns resolver
 
 
@@ -145,8 +145,8 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.server.{n}.listen`: [required]: Defines a listening address and/or ports
 * `haproxy_listen.{n}.server.{n}.param`: [optional]: A list of parameters for this server
 * `haproxy_listen.{n}.server_template`: [optional]: Server template declarations
-* `haproxy_listen.{n}.server_template.{n}.name`: [required]: The internal name assigned to this server
-* `haproxy_listen.{n}.server_template.{n}.number`: [required]: The internal dns records number assigned to this server
+* `haproxy_listen.{n}.server_template.{n}.prefix`: [required]: The internal name assigned to this server
+* `haproxy_listen.{n}.server_template.{n}.num`: [required]: The internal dns records number assigned to this server
 * `haproxy_listen.{n}.server_template.{n}.listen`: [required]: Defines a listening address and/or ports
 * `haproxy_listen.{n}.server_template.{n}.param`: [optional]: A list of parameters for this server
 
@@ -417,11 +417,11 @@ None
             param: 'X-Forwarded-Proto https'
             cond: 'if { ssl_fc }'
         server_template:
-          - name: web
-          	number: 3
+          - id: web
+          	num: 3
             listen: "_http._tcp.web.skydns.local:80"
             param:
-              - 'resolvers {{ haproxy_resolvers_label }}'
+              - 'resolvers {{ haproxy_resolverslist }}'
               - 'maxconn 501'
               - check
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_defaults_compression`: [optional]: Compression declarations
 * `haproxy_defaults_compression.{}.name`: [required]: The compression name (e.g. `algo`, `type`, `offload`)
 * `haproxy_defaults_compression.{}.value`: [required]: The compression value, (e.g. if name = algo : one of this values `identity`, `gzip`, `deflate`, `raw-deflate` / if name = type : list of mime type separated by space for example `text/html text/plain text/css` / if name = `offload` value is empty)
+  
+* `haproxy_resolvers_label`: [default: `[]`]: The global name of your dns resolver
+* `haproxy_resolvers_list.{n}.name`: [required]: The name of the dns resolver
+* `haproxy_resolvers_list.{n}.listen`: [required]: The location of your dns resolver
+
 
 * `haproxy_ssl_map`: [default: `[]`]: SSL declarations
 * `haproxy_ssl_map.{n}.src`: The local path of the file to copy, can be absolute or relative (e.g. `../../../files/haproxy/etc/haproxy/ssl/star-example-com.pem`)
@@ -139,6 +144,13 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.server.{n}.name`: [required]: The internal name assigned to this server
 * `haproxy_listen.{n}.server.{n}.listen`: [required]: Defines a listening address and/or ports
 * `haproxy_listen.{n}.server.{n}.param`: [optional]: A list of parameters for this server
+
+* `haproxy_listen.{n}.server_template`: [optional]: Server template declarations
+* `haproxy_listen.{n}.server_template.{n}.name`: [required]: The internal name assigned to this server
+* `haproxy_listen.{n}.server_template.{n}.number`: [required]: The internal dns records number assigned to this server
+* `haproxy_listen.{n}.server_template.{n}.listen`: [required]: Defines a listening address and/or ports
+* `haproxy_listen.{n}.server_template.{n}.param`: [optional]: A list of parameters for this server
+
 * `haproxy_listen.{n}.rspadd`: [optional]: Adds headers at the end of the HTTP response
 * `haproxy_listen.{n}.rspadd.{n}.string`: [required]: The complete line to be added. Any space or known delimiter must be escaped using a backslash (`'\'`) (in version < 1.6)
 * `haproxy_listen.{n}.rspadd.{n}.cond`: [optional]: A matching condition built from ACLs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,7 @@ haproxy_defaults_errorfile:
 
 haproxy_resolvers_label: sddns
 haproxy_resolvers_list: []
-  # - name: dns1
+  # - id: dns1
   #   listen: 127.0.0.1:5353
 
 # ssl (file) map

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,12 @@ haproxy_defaults_errorfile:
   - code: 504
     file: /etc/haproxy/errors/504.http
 
+
+haproxy_resolvers_label: sddns
+haproxy_resolvers_list: []
+  # - name: dns1
+  #   listen: 127.0.0.1:5353
+
 # ssl (file) map
 haproxy_ssl_map: []
 

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -106,10 +106,19 @@ backend {{ backend.name }}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
 
+{% if backend.server is defined %}
 {% for server in backend.server | default([]) %}
   server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
+{% endif %}
+
+{% if backend.server_template is defined %}
+{% for server in backend.server_template | default([]) %}
+  server-template {{ server.name }} {{ server.number }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
+
+{% endfor %}
+{% endif %}
 
 {% for errorfile in backend.errorfile | default([]) %}
   errorfile {{ errorfile.code }} {{ errorfile.file }}

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -115,7 +115,7 @@ backend {{ backend.name }}
 
 {% if backend.server_template is defined %}
 {% for server in backend.server_template | default([]) %}
-  server-template {{ server.name }} {{ server.number }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
+  server-template {{ server.prefix }} {{ server.num }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
 {% endif %}

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -6,7 +6,7 @@ global
 defaults
 {% include 'defaults.cfg.j2' %}
 
-{% include 'resolvers.cfg.j2' %}
+{% include 'resolverslist.cfg.j2' %}
 
 {% include 'userlist.cfg.j2' %}
 

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -6,6 +6,8 @@ global
 defaults
 {% include 'defaults.cfg.j2' %}
 
+{% include 'resolvers.cfg.j2' %}
+
 {% include 'userlist.cfg.j2' %}
 
 {% include 'listen.cfg.j2' %}

--- a/templates/etc/haproxy/resolvers.cfg.j2
+++ b/templates/etc/haproxy/resolvers.cfg.j2
@@ -1,0 +1,8 @@
+{% if haproxy_resolvers_label is defined %}
+resolvers {{ haproxy_resolvers_label }}
+{% if haproxy_resolvers_list is defined %}
+{% for resolver in haproxy_resolvers_list %}
+  nameserver {{ resolver.name }} {{ resolver.listen }} 
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/templates/etc/haproxy/resolvers.cfg.j2
+++ b/templates/etc/haproxy/resolvers.cfg.j2
@@ -1,8 +1,0 @@
-{% if haproxy_resolvers_label is defined %}
-resolvers {{ haproxy_resolvers_label }}
-{% if haproxy_resolvers_list is defined %}
-{% for resolver in haproxy_resolvers_list %}
-  nameserver {{ resolver.name }} {{ resolver.listen }} 
-{% endfor %}
-{% endif %}
-{% endif %}

--- a/templates/etc/haproxy/resolverslist.cfg.j2
+++ b/templates/etc/haproxy/resolverslist.cfg.j2
@@ -1,0 +1,8 @@
+{% if haproxy_resolvers_label is defined %}
+resolvers {{ haproxy_resolvers_label }}
+{% if haproxy_resolverslist is defined %}
+{% for resolver in haproxy_resolverslist %}
+  nameserver {{ resolver.id }} {{ resolver.listen }} 
+{% endfor %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Hi,

I am using coredns as a secondary dns resolver.
Main goal: adding service discovery to haproxy

[Link](https://www.haproxy.com/documentation/aloha/9-5/traffic-management/lb-layer7/dns-srv-records/)

```
resolvers test
   nameserver dns1 192.168.0.2:5353

backend be_app
   balance            roundrobin
   cookie             SERVERID insert indirect nocache
   server-template srv 3 _http._tcp.web.skydns.local resolvers test check
```