### PR TITLE
cleaning up template whitespace

### DIFF
--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -3,81 +3,63 @@ backend {{ backend.name }}
 {% if backend.description is defined %}
   description {{ backend.description }}
 {% endif %}
-
 {% if backend.bind_process is defined %}
   bind-process {{ backend.bind_process | join(' ') }}
 {% endif %}
-
   mode {{ backend.mode }}
-
   balance {{ backend.balance }}
-
 {% if backend.source is defined %}
   source {{ backend.source }}
 {% endif %}
-
 {% for option in backend.option | default([])%}
   option {{ option }}
 {% endfor %}
-
 {% for option in backend.no_option | default([])%}
   no option {{ option }}
 {% endfor %}
-
 {% if backend.http_check is defined %}
   http-check {{ backend.http_check }}
 {% endif %}
-
 {% if backend.cookie is defined %}
   cookie {{ backend.cookie }}
 {% endif %}
-
 {% for acl in backend.acl | default([]) %}
   acl {{ acl.string }}
 {% endfor %}
-
 {% for stick in backend.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}
 {% endfor %}
-
 {% for option in backend.no_option | default([]) %}
   no option {{ option }}
 {% endfor %}
-
 {% if backend.no_log | default(false) == true %}
   no log
 {% endif %}
-
 {% for tcp_check in backend.tcp_check | default([]) %}
   tcp-check {{ tcp_check }}
 {% endfor %}
-
 {% for timeout in backend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in backend[action] | default([]) %}
   {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in backend[action] | default([]) %}
   {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in backend[action] | default([]) %}
   {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% if backend.stats is defined %}
 {% if backend.stats.enable is defined and backend.stats.enable | bool == true %}
   stats enable
@@ -93,58 +75,49 @@ backend {{ backend.name }}
 {% endfor %}
 {% for auth in backend.stats.auth | default([]) %}
   stats auth {{ auth.user }}:{{ auth.passwd }}
-
 {% endfor %}
 {% endif %}
 {% endif %}
-
 {% for http_request in backend.http_request | default([]) %}
   http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
 
 {% endfor %}
-
 {% for tcp_request_inspect_delay in backend.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
-
 {% endfor %}
-
 {% for tcp_request_content in backend.tcp_request_content | default([]) %}
   tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
 
 {% endfor %}
-
 {% for http_response in backend.http_response | default([]) %}
   http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
 
 {% endfor %}
-
 {% for compression in backend.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
-
 {% if backend.default_server_params | default([]) %}
   default-server {% for param in backend.default_server_params | default([]) %} {{ param }}{% endfor %}
-{% endif %}
 
+{% endif %}
 {% for server in backend.server | default([]) %}
   server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
 {% if backend.server_template is defined %}
   server-template {{ backend.server_template.name }} {{ backend.server_template.num}} {{ backend.server_template.fqdn }}{% if backend.server_template.port is defined %}:{{ backend.server_template.port }}{% endif %} {% for param in backend.server_template.param | default([]) %} {{ param }}{% endfor %}
-{% endif %}
 
+{% endif %}
 {% if backend.retry_on is defined %}
   retry-on {% for r in backend.retry_on %}{{ r }} {% endfor %}
-{% endif %}
 
+{% endif %}
 {% if backend.retries is defined %}
   retries {{ backend.retries }}
 {% endif %}
 {% for errorfile in backend.errorfile | default([]) %}
   errorfile {{ errorfile.code }} {{ errorfile.file }}
 {% endfor %}
-
 {% for line in backend.raw_options | default([]) %}
   {{ line }}
 {% endfor %}

--- a/templates/etc/haproxy/defaults.cfg.j2
+++ b/templates/etc/haproxy/defaults.cfg.j2
@@ -1,41 +1,33 @@
 {% if haproxy_defaults_log != false %}
   log {{ haproxy_defaults_log }}
 {% endif %}
-
 {% if haproxy_defaults_logformat is defined %}
   log-format {{ haproxy_defaults_logformat }}
 {% endif %}
-
 {% if haproxy_defaults_mode != false %}
   mode {{ haproxy_defaults_mode }}
 {% endif %}
-
 {% if haproxy_defaults_source is defined %}
   source {{ haproxy_defaults_source }}
 {% endif %}
-
 {% if haproxy_defaults_option != false %}
 {% for option in haproxy_defaults_option %}
   option {{ option }}
 {% endfor %}
 {% endif %}
-
 {% for option in haproxy_defaults_no_option | default([]) %}
   no option {{ option }}
 {% endfor %}
-
 {% if haproxy_defaults_timeout != false %}
 {% for timeout in haproxy_defaults_timeout %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
 {% endif %}
-
 {% if haproxy_defaults_errorfile != false %}
 {% for errorfile in haproxy_defaults_errorfile %}
   errorfile {{ errorfile.code }} {{ errorfile.file }}
 {% endfor %}
 {% endif %}
-
 {% for compression in haproxy_defaults_compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -3,114 +3,89 @@ frontend {{ frontend.name }}
 {% if frontend.description is defined %}
   description {{ frontend.description }}
 {% endif %}
-
 {% for bind in frontend.bind %}
   bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
-
 {% if frontend.bind_process is defined %}
   bind-process {{ frontend.bind_process | join(' ') }}
 {% endif %}
-
   mode {{ frontend.mode }}
-
 {% if frontend.maxconn is defined %}
   maxconn {{ frontend.maxconn }}
 {% endif %}
-
 {% for stick in frontend.stick | default([]) %}
   stick-table {{ stick.table }}
 {% endfor %}
-
 {% for option in frontend.option | default([]) %}
   option {{ option }}
 {% endfor %}
-
 {% for option in frontend.no_option | default([]) %}
   no option {{ option }}
 {% endfor %}
-
 {% if frontend.logformat is defined %}
   log-format {{ frontend.logformat }}
 {% endif %}
-
 {% if frontend.no_log | default(false) == true %}
   no log
 {% endif %}
-
 {% for timeout in frontend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-
 {% for acl in frontend.acl | default([]) %}
   acl {{ acl.string }}
 {% endfor %}
-
 {% for capture in frontend.capture | default([]) %}
   capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
 {% endfor %}
-
 {% for tcp_request_inspect_delay in frontend.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
-
 {% endfor %}
-
 {% for tcp_request_connection in frontend.tcp_request_connection | default([]) %}
   tcp-request connection {{ tcp_request_connection.action }}{% if tcp_request_connection.cond is defined %} {{ tcp_request_connection.cond }}{% endif %}
 
 {% endfor %}
-
 {% for tcp_request_content in frontend.tcp_request_content | default([]) %}
   tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
 
 {% endfor %}
-
 {% for tcp_request_session in frontend.tcp_request_session | default([]) %}
   tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
 
 {% endfor %}
-
 {% for http_request in frontend.http_request | default([]) %}
   http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
 
 {% endfor %}
-
 {% for http_response in frontend.http_response | default([]) %}
   http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
 
 {% endfor %}
-
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in frontend[action] | default([]) %}
   {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in frontend[action] | default([]) %}
   {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in frontend[action] | default([]) %}
   {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for redirect in frontend.redirect | default([]) %}
   redirect {{ redirect.string }}{% if redirect.cond is defined %} {{ redirect.cond }}{% endif %}
 
 {% endfor %}
-
 {% for compression in frontend.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
-
 {% if frontend.use_backend is defined %}
 {% if frontend.use_backend is iterable and frontend.use_backend is not string %}
 {% for use_backend in frontend.use_backend | default([]) %}
@@ -120,15 +95,12 @@ frontend {{ frontend.name }}
   use_backend {{ frontend.use_backend }}
 {% endif %}
 {% endif %}
-
 {% if frontend.default_backend is defined %}
   default_backend {{ frontend.default_backend }}
 {% endif %}
-
 {% for errorfile in frontend.errorfile | default([]) %}
   errorfile {{ errorfile.code }} {{ errorfile.file }}
 {% endfor %}
-
 {% for line in frontend.raw_options | default([]) %}
   {{ line }}
 {% endfor %}

--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -4,11 +4,9 @@
 
 {% endfor %}
 {% endif %}
-
 {% if haproxy_global_chroot is defined %}
   chroot {{ haproxy_global_chroot }}
 {% endif %}
-
 {% if haproxy_global_stats != false %}
 {% for socket in haproxy_global_stats.sockets | default([]) %}
   stats socket {{ socket.listen }}{% for param in socket.param | default([]) %} {{ param }}{% endfor %}
@@ -18,95 +16,75 @@
   stats timeout {{ haproxy_global_stats.timeout }}
 {% endif -%}
 {% endif %}
-
 {% if haproxy_global_user != false %}
   user {{ haproxy_global_user }}
 {% endif %}
-
 {% if haproxy_global_group != false %}
   group {{ haproxy_global_group }}
 {% endif %}
-
 {% if haproxy_global_daemon | bool == true %}
   daemon
 {% endif %}
-
 {% if haproxy_global_master_worker | default(false) | bool %}
   master-worker
 {% endif %}
-
 {% if haproxy_global_maxconn is defined %}
   maxconn {{ haproxy_global_maxconn }}
 {% endif %}
-
 {% if haproxy_global_ca_base != false %}
   # Default SSL material locations
   ca-base {{ haproxy_global_ca_base }}
 {% endif %}
-
 {% if haproxy_global_crt_base != false %}
   crt-base {{ haproxy_global_crt_base }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_bind_ciphers != false %}
   # Default ciphers to use on SSL-enabled listening sockets.
   # For more information, see ciphers(1SSL). This list is from:
   #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
   ssl-default-bind-ciphers {{ haproxy_global_ssl_default_bind_ciphers }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_bind_ciphersuites %}
   ssl-default-bind-ciphersuites {{ haproxy_global_ssl_default_bind_ciphersuites }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_bind_options != false %}
   ssl-default-bind-options {{ haproxy_global_ssl_default_bind_options }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_server_ciphers != false %}
   # Default ciphers to use on SSL-enabled listening sockets.
   # For more information, see ciphers(1SSL). This list is from:
   #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
   ssl-default-server-ciphers {{ haproxy_global_ssl_default_server_ciphers }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_server_ciphersuites %}
   ssl-default-server-ciphersuites {{ haproxy_global_ssl_default_server_ciphersuites }}
 {% endif %}
-
 {% if haproxy_global_ssl_default_server_options != false %}
   ssl-default-server-options {{ haproxy_global_ssl_default_server_options }}
 {% endif %}
-
 {% for ssl_engine in haproxy_global_ssl_engines | default([]) %}
   ssl-engine {{ ssl_engine.name }}{% if ssl_engine.algos | default([]) | length %} algo {{ ssl_engine.algos | join(', ') }}{% endif %}
-{% endfor %}
 
+{% endfor %}
 {% if haproxy_global_ssl_mode_async | default(false) | bool %}
   ssl-mode-async
 {% endif %}
-
   nbproc {{ haproxy_global_nbproc }}
-
 {% if haproxy_global_nbthread is defined %}
   nbthread {{ haproxy_global_nbthread }}
 {% endif %}
-
 {% for tune in haproxy_global_tune | default([]) %}
   tune.{{ tune.key }} {{ tune.value }}
 {% endfor %}
-
 {% for option in haproxy_global_option | default([]) %}
   {{ option }}
 {% endfor %}
-
 {% for peers in haproxy_global_peers | default([]) %}
 peers {{ peers.name }}
 {% for peer in peers.peers | default([]) %}
   peer {{ peer.name }} {{ peer.listen }}
 {% endfor %}
 {% endfor %}
-
 {% for line in haproxy_global_raw_options | default([]) %}
   {{ line }}
 {% endfor %}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -3,67 +3,51 @@ listen {{ listen.name }}
 {% if listen.description is defined %}
   description {{ listen.description }}
 {% endif %}
-
 {% for bind in listen.bind %}
   bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
-
 {% if listen.bind_process is defined %}
   bind-process {{ listen.bind_process | join(' ') }}
 {% endif %}
-
   mode {{ listen.mode }}
-
 {% if listen.balance is defined %}
   balance {{ listen.balance }}
 {% endif %}
-
 {% if listen.maxconn is defined %}
   maxconn {{ listen.maxconn }}
 {% endif %}
-
 {% if listen.http_check is defined %}
   http-check {{ listen.http_check }}
 {% endif %}
-
 {% for stick in listen.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}
 {% endfor %}
-
 {% if listen.source is defined %}
   source {{ listen.source }}
 {% endif %}
-
 {% for option in listen.option | default([]) %}
   option {{ option }}
 {% endfor %}
-
 {% for option in listen.no_option | default([])  %}
   no option {{ option }}
 {% endfor %}
-
 {% if listen.no_log | default(false) == true %}
   no log
 {% endif %}
-
 {% for tcp_check in listen.tcp_check | default([]) %}
   tcp-check {{ tcp_check }}
 {% endfor %}
-
 {% for timeout in listen.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-
 {% for acl in listen.acl | default([]) %}
   acl {{ acl.string }}
 {% endfor %}
-
 {% for capture in listen.capture | default([]) %}
   capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
 {% endfor %}
-
 {% if listen.stats is defined %}
 {% if listen.stats.enable is defined and listen.stats.enable | bool == true %}
   stats enable
@@ -79,94 +63,79 @@ listen {{ listen.name }}
 {% endfor %}
 {% for auth in listen.stats.auth | default([]) %}
   stats auth {{ auth.user }}:{{ auth.passwd }}
-
 {% endfor %}
 {% endif %}
 {% endif %}
-
 {% for tcp_request_inspect_delay in listen.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
-
 {% endfor %}
-
 {% for tcp_request_connection in listen.tcp_request_connection | default([]) %}
   tcp-request connection {{ tcp_request_connection.action }}{% if tcp_request_connection.cond is defined %} {{ tcp_request_connection.cond }}{% endif %}
 
 {% endfor %}
-
 {% for tcp_request_content in listen.tcp_request_content | default([]) %}
   tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
 
 {% endfor %}
-
 {% for tcp_request_session in listen.tcp_request_session | default([]) %}
   tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
 
 {% endfor %}
-
 {% for http_request in listen.http_request | default([]) %}
   http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
 
 {% endfor %}
-
 {% for http_response in listen.http_response | default([]) %}
   http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
 
 {% endfor %}
-
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in listen[action] | default([]) %}
   {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in listen[action] | default([]) %}
   {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in listen[action] | default([]) %}
   {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
 
 {% endfor %}
 {% endfor %}
-
 {% for redirect in listen.redirect | default([]) %}
   redirect {{ redirect.string }}{% if redirect.cond is defined %} {{ redirect.cond }}{% endif %}
 
 {% endfor %}
-
 {% for compression in listen.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
-
 {% if listen.default_server_params | default([]) %}
   default-server {% for param in listen.default_server_params | default([]) %} {{ param }}{% endfor %}
-{% endif %}
 
+{% endif %}
 {% for server in listen.server | default([]) %}
   server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
 
 {% endfor %}
 {% if listen.server_template is defined %}
   server-template {{ listen.server_template.name }} {{ listen.server_template.num}} {{ listen.server_template.fqdn }}{% if listen.server_template.port is defined %}:{{ listen.server_template.port }}{% endif %} {% for param in listen.server_template.param | default([]) %} {{ param }}{% endfor %}
-{% endif %}
 
+{% endif %}
 {% if listen.retry_on is defined %}
   retry-on {% for r in listen.retry_on %}{{ r }}{% endfor %}
-{% endif %}
 
+{% endif %}
 {% if listen.retries is defined %}
   retries {{ listen.retries }}
 {% endif %}
 {% for errorfile in listen.errorfile | default([]) %}
   errorfile {{ errorfile.code }} {{ errorfile.file }}
 {% endfor %}
-
 {% for line in listen.raw_options | default([]) %}
   {{ line }}
 {% endfor %}


### PR DESCRIPTION
Hello,

This PR cleans up white space in the haproxy.cfg templates.  There were many extra newlines, which made the resulting file difficult to parse visually.  This commit leaves newlines only where they are required or are visually pleasing.  Please let me know if anything needs to be tweaked for this to be accepted.