### PR TITLE
bump haproxy version to 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 
 #### Variables
 
-* `haproxy_version`: [default: `1.6`]: Version to install (e.g. `1.5`, `1.6`, `1.7`, `1.8`)
+* `haproxy_version`: [default: `1.8`]: Version to install (e.g. `1.5`, `1.6`, `1.7`, `1.8`)
 
 * `haproxy_install`: [default: `[]`]: Additional packages to install (e.g. `socat`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # defaults file for haproxy
 ---
-haproxy_version: 1.6
+haproxy_version: 1.8
 
 haproxy_dependencies:
   - name: haproxy

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -6,4 +6,4 @@
   roles:
     - ../../
   vars:
-    haproxy_version: "{{ (ansible_distribution_version is version_compare('18.04', '>=')) | ternary(1.7, 1.6) }}"
+    haproxy_version: "{{ (ansible_distribution_version is version_compare('18.04', '>=')) | ternary(1.8) }}"


### PR DESCRIPTION
Since Ubuntu 18.04 only supports haproxy version >=1.7 and LTS version down to 14.04 still support haproxy 1.8, we should move over to that version.