### PR TITLE
a 'tcp-request' rule placed after an 'http-request' rule will still b…

### DIFF
--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -51,16 +51,6 @@ frontend {{ frontend.name }}
   capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
 {% endfor %}
 
-{% for http_request in frontend.http_request | default([]) %}
-  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
-
-{% endfor %}
-
-{% for http_response in frontend.http_response | default([]) %}
-  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
-
-{% endfor %}
-
 {% for tcp_request_inspect_delay in frontend.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
 
@@ -78,6 +68,16 @@ frontend {{ frontend.name }}
 
 {% for tcp_request_session in frontend.tcp_request_session | default([]) %}
   tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
+
+{% endfor %}
+
+{% for http_request in frontend.http_request | default([]) %}
+  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
+
+{% endfor %}
+
+{% for http_response in frontend.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
 
 {% endfor %}
 

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -84,11 +84,6 @@ listen {{ listen.name }}
 {% endif %}
 {% endif %}
 
-{% for http_request in listen.http_request | default([]) %}
-  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
-
-{% endfor %}
-
 {% for tcp_request_inspect_delay in listen.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
 
@@ -106,6 +101,11 @@ listen {{ listen.name }}
 
 {% for tcp_request_session in listen.tcp_request_session | default([]) %}
   tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
+
+{% endfor %}
+
+{% for http_request in listen.http_request | default([]) %}
+  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
 
 {% endfor %}
 


### PR DESCRIPTION
When there are a tcp-request and http-request in the same frontend or listen, haproxy config test show a warning:

```
a 'tcp-request' rule placed after an 'http-request' rule will still be processed before
```

I've moved tcp-request before http-request in both ansible template