### PR TITLE
Enable HAProxy 2.0 LTS release

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,5 +6,6 @@ haproxy_versions_supported:
   - '1.7'
   - '1.8'
   - '1.9'
+  - '2.0'
 
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"


### PR DESCRIPTION
I'm using this ansible role with HAProxy 2.0. It seems to work well