### PR TITLE
Multi-distribution support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,11 @@
 # defaults file for haproxy
 ---
+#Moved these variables to distribution specific var include
+#haproxy_version
+
+#haproxy_dependencies:
+#haproxy_install: []
+
 haproxy_restart_handler_state: restarted
 
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,6 @@
 ---
 haproxy_version: 1.8
 
-haproxy_dependencies:
-  - name: haproxy
-    state: latest
-haproxy_install: []
-
 haproxy_restart_handler_state: restarted
 
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,5 @@
 # defaults file for haproxy
 ---
-haproxy_version: 1.8
-
 haproxy_restart_handler_state: restarted
 
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,10 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
+    - name: Debian
+      versions:
+        - stretch
+        - buster
   galaxy_tags:
     - system
     - clustering

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,24 +1,4 @@
 # tasks file for haproxy
 ---
-- name: install | add repository from PPA and install its signing key
-  apt_repository:
-    repo: "{{ haproxy_ppa }}"
-    update_cache: true
-  tags:
-    - haproxy-install-add-repository
+- include: install/main.yml
 
-- name: install | dependencies
-  apt:
-    name: "{{ item.name }}"
-    state: "{{ item.state }}"
-  with_items: "{{ haproxy_dependencies }}"
-  tags:
-    - haproxy-install-dependencies
-
-- name: install | additional
-  apt:
-    name: "{{ item }}"
-    state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ haproxy_install }}"
-  tags:
-    - haproxy-install-additional

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,0 @@
-# tasks file for haproxy
----
-- include: install/main.yml
-

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -2,12 +2,13 @@
 ---
 - name: install | add repository from backport and install its signing key
   apt_repository:
-    repo: "deb http://deb.debian.org/debian {{ haproxy_repo }} main"
+    repo: "deb http://deb.debian.org/debian {{ haproxy_add_repo }} main"
     state: present
     update_cache: yes
   tags:
     - haproxy-install-add-repository
 
+# Debian backport repos have a lower priority than default which requires a specific release to be specified
 - name: install | dependencies
   apt:
     name: "{{ item.name }}"

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,0 +1,26 @@
+# tasks file for haproxy
+---
+- name: install | add repository from backport and install its signing key
+  apt_repository:
+    repo: "deb http://deb.debian.org/debian {{ haproxy_repo }} main"
+    state: present
+    update_cache: yes
+  tags:
+    - haproxy-install-add-repository
+
+- name: install | dependencies
+  apt:
+    name: "{{ item.name }}"
+    default_release: "{{ item.default_release }}"
+    state: "{{ item.state }}"
+  with_items: "{{ haproxy_dependencies }}"
+  tags:
+    - haproxy-install-dependencies
+
+- name: install | additional
+  apt:
+    name: "{{ item }}"
+    state: "{{ apt_install_state | default('latest') }}"
+  with_items: "{{ haproxy_install }}"
+  tags:
+    - haproxy-install-additional

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -1,0 +1,24 @@
+# tasks file for haproxy
+---
+- name: install | add repository from PPA and install its signing key
+  apt_repository:
+    repo: "{{ haproxy_ppa }}"
+    update_cache: true
+  tags:
+    - haproxy-install-add-repository
+
+- name: install | dependencies
+  apt:
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+  with_items: "{{ haproxy_dependencies }}"
+  tags:
+    - haproxy-install-dependencies
+
+- name: install | additional
+  apt:
+    name: "{{ item }}"
+    state: "{{ apt_install_state | default('latest') }}"
+  with_items: "{{ haproxy_install }}"
+  tags:
+    - haproxy-install-additional

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -1,0 +1,4 @@
+---
+
+- include: "install/{{ ansible_facts['distribution'] }}.yml"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 # tasks file for haproxy
 ---
+- name: Include distribution vars
+  include: "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+
 - name: check version support
   fail:
     msg: "HAProxy version {{ haproxy_version }} is not supported"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     - haproxy
     - haproxy-check-version-support
 
-- include: install.yml
+- include: install/main.yml
   tags:
     - configuration
     - haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # tasks file for haproxy
 ---
 - name: Include distribution vars
-  include: "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+  include_vars: "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
 
 - name: check version support
   fail:

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,8 +1,12 @@
 ---
-haproxy_version: 2.0
-haproxy_repo: buster-backports
+haproxy_version: 1.8
+haproxy_add_repo: buster-backports
+# buster repo contains haproxy 1.8
+# buster-backports repo contains haproxy 2.0
+haproxy_install_repo: buster
+#haproxy_install_repo: buster-backports
 haproxy_dependencies:
   - name: haproxy
-    default_release: "{{ haproxy_repo }}"
+    default_release: "{{ haproxy_install_repo }}"
     state: latest
 haproxy_install: []

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 2.0
 haproxy_repo: buster-backports
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,6 @@
+---
+haproxy_repo: buster-backports
+haproxy_dependencies:
+  - name: haproxy
+    default_release: "{{ haproxy_repo }}"
+    state: latest

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -4,3 +4,4 @@ haproxy_dependencies:
   - name: haproxy
     default_release: "{{ haproxy_repo }}"
     state: latest
+haproxy_install: []

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,8 +1,9 @@
 ---
 haproxy_version: 1.8
-haproxy_repo: stretch-backports
+haproxy_add_repo: stretch-backports
+haproxy_install_repo: stretch-backports
 haproxy_dependencies:
   - name: haproxy
-    default_release: "{{ haproxy_repo }}"
+    default_release: "{{ haproxy_install_repo }}"
     state: latest
 haproxy_install: []

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,0 +1,6 @@
+---
+haproxy_repo: stretch-backports
+haproxy_dependencies:
+  - name: haproxy
+    default_release: "{{ haproxy_repo }}"
+    state: latest

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -4,3 +4,4 @@ haproxy_dependencies:
   - name: haproxy
     default_release: "{{ haproxy_repo }}"
     state: latest
+haproxy_install: []

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 1.8
 haproxy_repo: stretch-backports
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Ubuntu-12.yml
+++ b/vars/Ubuntu-12.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 1.8
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Ubuntu-12.yml
+++ b/vars/Ubuntu-12.yml
@@ -1,0 +1,6 @@
+---
+haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
+haproxy_dependencies:
+  - name: haproxy
+    state: latest
+haproxy_install: []

--- a/vars/Ubuntu-14.yml
+++ b/vars/Ubuntu-14.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 1.8
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Ubuntu-14.yml
+++ b/vars/Ubuntu-14.yml
@@ -1,0 +1,6 @@
+---
+haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
+haproxy_dependencies:
+  - name: haproxy
+    state: latest
+haproxy_install: []

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 1.8
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,0 +1,6 @@
+---
+haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
+haproxy_dependencies:
+  - name: haproxy
+    state: latest
+haproxy_install: []

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_version: 1.8
 haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
 haproxy_dependencies:
   - name: haproxy

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,0 +1,6 @@
+---
+haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"
+haproxy_dependencies:
+  - name: haproxy
+    state: latest
+haproxy_install: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,4 +9,3 @@ haproxy_versions_supported:
   - '2.0'
   - '2.1'
 
-haproxy_ppa: "ppa:vbernat/haproxy-{{ haproxy_version }}"


### PR DESCRIPTION
Create separate install code path for Debian distribution.  Create distribution specific vars files included in the main task.

Adding new distributions, eg CentOS, should be extremely easy with this structure.