### PR TITLE
haproxy.cfg tidy and all no backend mode if backend.status exists

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -11,3 +11,15 @@
   notify: restart haproxy
   tags:
     - haproxy-configuration-update-file
+
+- name: configuration | format file (remove empty)
+  lineinfile:
+    path: /etc/haproxy/haproxy.cfg
+    regex: '^\n'
+    state: absent
+
+- name: configuration | format file (empty before headings)
+  replace:
+    dest: /etc/haproxy/haproxy.cfg
+    regexp: "^#--#"
+    replace: ""

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -8,9 +8,11 @@ backend {{ backend.name }}
   bind-process {{ backend.bind_process | join(' ') }}
 {% endif %}
 
+{% if backend.mode is not defined and backend.stats is defined %}
+{% else %}
   mode {{ backend.mode }}
-
-  balance {{ backend.balance }}
+  balance {{ backend.balance | default('roundrobin') }}
+{% endif %}
 
 {% if backend.source is defined %}
   source {{ backend.source }}

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -1,17 +1,30 @@
 # {{ ansible_managed }}
-
+#--#
+# Global
 global
 {% include 'global.cfg.j2' %}
 
+#--#
+# Defaults
 defaults
 {% include 'defaults.cfg.j2' %}
 
+#--#
+# Userlist
 {% include 'userlist.cfg.j2' %}
 
+#--#
+# Resolvers
 {% include 'resolvers.cfg.j2' %}
 
+#--#
+# Listen
 {% include 'listen.cfg.j2' %}
 
+#--#
+# Frontend
 {% include 'frontend.cfg.j2' %}
 
+#--#
+# Backend
 {% include 'backend.cfg.j2' %}


### PR DESCRIPTION
These commits 
- tidy the haproxy.cfg to make it easier for humans to read by removing excess blank lines and adding headings for sections. Outputs like below
```
  errorfile 408 /etc/haproxy/errors/408.http
  errorfile 500 /etc/haproxy/errors/500.http
  errorfile 502 /etc/haproxy/errors/502.http
  errorfile 503 /etc/haproxy/errors/503.http
  errorfile 504 /etc/haproxy/errors/504.http

# Userlist

# Listen

# Frontend
frontend http
  bind 0.0.0.0:80
  mode http
  use_backend foo if { hdr(host) -i foo.com }
  use_backend bar if { hdr(host) -i bar.com }

# Backend
backend foo
  description dnsdist
  mode http
  balance roundrobin
  server foo-server 127.0.0.1:5380
backend bar
  description powerdns recursor
  mode http
  balance roundrobin
  server bar-server 127.0.0.1:5381

```
- allows the skipping of a backend mode so long as backend.status is set

ansible vars
```
  - name: stats
    stats:
      enable: true
      uri: /
      options:
        - show-desc
      refresh: 5s
      admin: if TRUE
```

haproxy.cfg
```
backend stats
  stats enable
  stats uri /
  stats refresh 5s
  stats admin if TRUE
  stats show-desc
``` 

