### PR TITLE
Adjust acl option yaml input syntax

### DIFF
--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -23,9 +23,17 @@ backend {{ backend.name }}
 {% if backend.cookie is defined %}
   cookie {{ backend.cookie }}
 {% endif %}
-{% for acl in backend.acl | default([]) %}
-  acl {{ acl.string }}
+{% if backend.acl is defined %}
+{% if backend.acl is mapping %}
+{% for name, value in backend.acl.items() %}
+  acl {{ name }} {{ value }}
 {% endfor %}
+{% else %}
+{% for acl in backend.acl | default([]) %}
+  acl {{ acl.string | default(acl) }}
+{% endfor %}
+{% endif %}
+{% endif %}
 {% for stick in backend.stick | default([]) %}
   stick-table {{ stick.table }}
   stick on {{ stick.stick_on }}

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -32,9 +32,17 @@ frontend {{ frontend.name }}
 {% for timeout in frontend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-{% for acl in frontend.acl | default([]) %}
-  acl {{ acl.string }}
+{% if frontend.acl is defined %}
+{% if frontend.acl is mapping %}
+{% for name, value in frontend.acl.items() %}
+  acl {{ name }} {{ value }}
 {% endfor %}
+{% else %}
+{% for acl in frontend.acl | default([]) %}
+  acl {{ acl.string | default(acl) }}
+{% endfor %}
+{% endif %}
+{% endif %}
 {% for capture in frontend.capture | default([]) %}
   capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
 {% endfor %}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -42,9 +42,17 @@ listen {{ listen.name }}
 {% for timeout in listen.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-{% for acl in listen.acl | default([]) %}
-  acl {{ acl.string }}
+{% if listen.acl is defined %}
+{% if listen.acl is mapping %}
+{% for name, value in listen.acl.items() %}
+  acl {{ name }} {{ value }}
 {% endfor %}
+{% else %}
+{% for acl in listen.acl | default([]) %}
+  acl {{ acl.string | default(acl) }}
+{% endfor %}
+{% endif %}
+{% endif %}
 {% for capture in listen.capture | default([]) %}
   capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
 {% endfor %}


### PR DESCRIPTION
Having an `acl` entry requiring a single dictionary member called `string` seemed a little superflous, so this patch adjusts the accepted syntax to include the following two examples, but also retain the `string` member format.

As an array of strings:
```yaml
haproxy_frontend:
  - name: 'be-http'
    ....
    acl:
      - "is_foo hdr(host) -i foo.com"
      - "is_bar hdr(host) -i bar.com"
```

As a dictionary of named rules:
```yaml
haproxy_backend:
  - name: 'be-http'
    ....
    acl:
      is_foo: "hdr(host) -i foo.com"
      is_bar: "hdr(host) -i bar.com"
```