### PR TITLE
Removal of jinja conditional blocks

### DIFF
--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -11,10 +11,10 @@ backend {{ backend.name }}
 {% if backend.source is defined %}
   source {{ backend.source }}
 {% endif %}
-{% for option in backend.option | default([])%}
+{% for option in backend.option | default([]) %}
   option {{ option }}
 {% endfor %}
-{% for option in backend.no_option | default([])%}
+{% for option in backend.no_option | default([]) %}
   no option {{ option }}
 {% endfor %}
 {% if backend.http_check is defined %}

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -44,20 +44,17 @@ backend {{ backend.name }}
 {% endfor %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in backend[action] | default([]) %}
-  {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in backend[action] | default([]) %}
-  {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in backend[action] | default([]) %}
-  {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% if backend.stats is defined %}
@@ -79,38 +76,31 @@ backend {{ backend.name }}
 {% endif %}
 {% endif %}
 {% for http_request in backend.http_request | default([]) %}
-  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
-
+  http-request {{ http_request.action }}{{ http_request.param is defined | ternary([''] + [http_request.param], []) | join(' ') }}{{ http_request.cond is defined | ternary([''] + [http_request.cond], []) | join(' ') }}
 {% endfor %}
 {% for tcp_request_inspect_delay in backend.tcp_request_inspect_delay | default([]) %}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
 {% endfor %}
 {% for tcp_request_content in backend.tcp_request_content | default([]) %}
-  tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
-
+  tcp-request content {{ tcp_request_content.action }}{{ tcp_request_content.cond is defined | ternary([''] + [tcp_request_content.cond], []) | join(' ') }}
 {% endfor %}
 {% for http_response in backend.http_response | default([]) %}
-  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
-
+  http-response {{ http_response.action }}{{ http_response.param is defined | ternary([''] + [http_response.param], []) | join(' ') }}{{ http_response.cond is defined | ternary([''] + [http_response.cond], []) | join(' ') }}
 {% endfor %}
 {% for compression in backend.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
 {% if backend.default_server_params | default([]) %}
-  default-server {% for param in backend.default_server_params | default([]) %} {{ param }}{% endfor %}
-
+  default-server {{ backend.default_server_params | join(' ') }}
 {% endif %}
 {% for server in backend.server | default([]) %}
-  server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
-
+  server {{ server.name }} {{ server.listen }}{{ ([''] + server.param | default([])) | join(' ') }}
 {% endfor %}
 {% if backend.server_template is defined %}
-  server-template {{ backend.server_template.name }} {{ backend.server_template.num}} {{ backend.server_template.fqdn }}{% if backend.server_template.port is defined %}:{{ backend.server_template.port }}{% endif %} {% for param in backend.server_template.param | default([]) %} {{ param }}{% endfor %}
-
+  server-template {{ backend.server_template.name }} {{ backend.server_template.num}} {{ backend.server_template.fqdn }}{{ backend.server_template.port is defined | ternary([''] + [backend.server_template.port], []) | join(':') }}{{ ([''] + backend.server_template.param | default([])) | join(' ') }}
 {% endif %}
 {% if backend.retry_on is defined %}
-  retry-on {% for r in backend.retry_on %}{{ r }} {% endfor %}
-
+  retry-on {{ backend.retry_on | join(' ') }}
 {% endif %}
 {% if backend.retries is defined %}
   retries {{ backend.retries }}

--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -4,8 +4,7 @@ frontend {{ frontend.name }}
   description {{ frontend.description }}
 {% endif %}
 {% for bind in frontend.bind %}
-  bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
-
+  bind {{ bind.listen }}{{ ([''] + bind.param | default([])) | join(' ') }}
 {% endfor %}
 {% if frontend.bind_process is defined %}
   bind-process {{ frontend.bind_process | join(' ') }}
@@ -42,46 +41,37 @@ frontend {{ frontend.name }}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
 {% endfor %}
 {% for tcp_request_connection in frontend.tcp_request_connection | default([]) %}
-  tcp-request connection {{ tcp_request_connection.action }}{% if tcp_request_connection.cond is defined %} {{ tcp_request_connection.cond }}{% endif %}
-
+  tcp-request connection {{ tcp_request_connection.action }}{{ tcp_request_connection.cond is defined | ternary([''] + [tcp_request_connection.cond], []) | join(' ') }}
 {% endfor %}
 {% for tcp_request_content in frontend.tcp_request_content | default([]) %}
-  tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
-
+  tcp-request content {{ tcp_request_content.action }}{{ tcp_request_content.cond is defined | ternary([''] + [tcp_request_content.cond], []) | join(' ') }}
 {% endfor %}
 {% for tcp_request_session in frontend.tcp_request_session | default([]) %}
-  tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
-
+  tcp-request session {{ tcp_request_session.action }}{{ tcp_request_session.cond is defined | ternary([''] + [tcp_request_session.cond], []) | join(' ') }}
 {% endfor %}
 {% for http_request in frontend.http_request | default([]) %}
-  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
-
+  http-request {{ http_request.action }}{{ http_request.param is defined | ternary([''] + [http_request.param], []) | join(' ') }}{{ http_request.cond is defined | ternary([''] + [http_request.cond], []) | join(' ') }}
 {% endfor %}
 {% for http_response in frontend.http_response | default([]) %}
-  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
-
+  http-response {{ http_response.action }}{{ http_response.param is defined | ternary([''] + [http_response.param], []) | join(' ') }}{{ http_response.cond is defined | ternary([''] + [http_response.cond], []) | join(' ') }}
 {% endfor %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in frontend[action] | default([]) %}
-  {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in frontend[action] | default([]) %}
-  {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in frontend[action] | default([]) %}
-  {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for redirect in frontend.redirect | default([]) %}
-  redirect {{ redirect.string }}{% if redirect.cond is defined %} {{ redirect.cond }}{% endif %}
-
+  redirect {{ redirect.string }}{{ redirect.cond is defined | ternary([''] + [redirect.cond], []) | join(' ') }}
 {% endfor %}
 {% for compression in frontend.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}

--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -1,7 +1,6 @@
 {% if haproxy_global_log != false %}
 {% for log in haproxy_global_log %}
-  log {{ log.address }}{% if log.length is defined %} len {{log.length }}{% endif %} {{ log.facility }}{% if log.level is defined %} {{log.level }}{% endif %}{% if log.minlevel is defined %} {{ log.minlevel }}{% endif %}
-
+  log {{ log.address }}{{ log.length is defined | ternary(['', 'len'] + [log.length], []) | join(' ') }} {{ log.facility }}{{ log.level is defined | ternary([''] + [log.level], []) | join(' ') }}{{ log.minlevel is defined | ternary([''] + [log.minlevel], []) | join(' ') }}
 {% endfor %}
 {% endif %}
 {% if haproxy_global_chroot is defined %}
@@ -9,8 +8,7 @@
 {% endif %}
 {% if haproxy_global_stats != false %}
 {% for socket in haproxy_global_stats.sockets | default([]) %}
-  stats socket {{ socket.listen }}{% for param in socket.param | default([]) %} {{ param }}{% endfor %}
-
+  stats socket {{ socket.listen }}{{ ([''] + socket.param | default([])) | join(' ') }}
 {% endfor %}
 {% if haproxy_global_stats.timeout is defined %}
   stats timeout {{ haproxy_global_stats.timeout }}
@@ -63,8 +61,7 @@
   ssl-default-server-options {{ haproxy_global_ssl_default_server_options }}
 {% endif %}
 {% for ssl_engine in haproxy_global_ssl_engines | default([]) %}
-  ssl-engine {{ ssl_engine.name }}{% if ssl_engine.algos | default([]) | length %} algo {{ ssl_engine.algos | join(', ') }}{% endif %}
-
+  ssl-engine {{ ssl_engine.name }}{{ ssl_engine.algos | default([]) | length | ternary([[' algo']]+[ssl_engine.algos], []) | map('join', ', ') | join(' ') }}
 {% endfor %}
 {% if haproxy_global_ssl_mode_async | default(false) | bool %}
   ssl-mode-async

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -4,8 +4,7 @@ listen {{ listen.name }}
   description {{ listen.description }}
 {% endif %}
 {% for bind in listen.bind %}
-  bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
-
+  bind {{ bind.listen }}{{ ([''] + bind.param | default([])) | join(' ') }}
 {% endfor %}
 {% if listen.bind_process is defined %}
   bind-process {{ listen.bind_process | join(' ') }}
@@ -70,65 +69,52 @@ listen {{ listen.name }}
   tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
 {% endfor %}
 {% for tcp_request_connection in listen.tcp_request_connection | default([]) %}
-  tcp-request connection {{ tcp_request_connection.action }}{% if tcp_request_connection.cond is defined %} {{ tcp_request_connection.cond }}{% endif %}
-
+  tcp-request connection {{ tcp_request_connection.action }}{{ tcp_request_connection.cond is defined | ternary([''] + [tcp_request_connection.cond], []) | join(' ') }}
 {% endfor %}
 {% for tcp_request_content in listen.tcp_request_content | default([]) %}
-  tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
-
+  tcp-request content {{ tcp_request_content.action }}{{ tcp_request_content.cond is defined | ternary([''] + [tcp_request_content.cond], []) | join(' ') }}
 {% endfor %}
 {% for tcp_request_session in listen.tcp_request_session | default([]) %}
-  tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
-
+  tcp-request session {{ tcp_request_session.action }}{{ tcp_request_session.cond is defined | ternary([''] + [tcp_request_session.cond], []) | join(' ') }}
 {% endfor %}
 {% for http_request in listen.http_request | default([]) %}
-  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
-
+  http-request {{ http_request.action }}{{ http_request.param is defined | ternary([''] + [http_request.param], []) | join(' ') }}{{ http_request.cond is defined | ternary([''] + [http_request.cond], []) | join(' ') }}
 {% endfor %}
 {% for http_response in listen.http_response | default([]) %}
-  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
-
+  http-response {{ http_response.action }}{{ http_response.param is defined | ternary([''] + [http_response.param], []) | join(' ') }}{{ http_response.cond is defined | ternary([''] + [http_response.cond], []) | join(' ') }}
 {% endfor %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in listen[action] | default([]) %}
-  {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
 {% for params in listen[action] | default([]) %}
-  {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
 {% for params in listen[action] | default([]) %}
-  {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
-
+  {{ action }} {{ params.search }} {{ params.string }}{{ params.cond is defined | ternary([''] + [params.cond], []) | join(' ') }}
 {% endfor %}
 {% endfor %}
 {% for redirect in listen.redirect | default([]) %}
-  redirect {{ redirect.string }}{% if redirect.cond is defined %} {{ redirect.cond }}{% endif %}
-
+  redirect {{ redirect.string }}{{ redirect.cond is defined | ternary([''] + [redirect.cond], []) | join(' ') }}
 {% endfor %}
 {% for compression in listen.compression | default([]) %}
   compression {{ compression.name }} {{ compression.value }}
 {% endfor %}
 {% if listen.default_server_params | default([]) %}
-  default-server {% for param in listen.default_server_params | default([]) %} {{ param }}{% endfor %}
-
+  default-server {{ listen.default_server_params | join(' ') }}
 {% endif %}
 {% for server in listen.server | default([]) %}
-  server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
-
+  server {{ server.name }} {{ server.listen }}{{ ([''] + server.param | default([])) | join(' ') }}
 {% endfor %}
 {% if listen.server_template is defined %}
-  server-template {{ listen.server_template.name }} {{ listen.server_template.num}} {{ listen.server_template.fqdn }}{% if listen.server_template.port is defined %}:{{ listen.server_template.port }}{% endif %} {% for param in listen.server_template.param | default([]) %} {{ param }}{% endfor %}
-
+  server-template {{ listen.server_template.name }} {{ listen.server_template.num}} {{ listen.server_template.fqdn }}{{ listen.server_template.port is defined | ternary([''] + [listen.server_template.port], []) | join(':') }}{{ ([''] + listen.server_template.param | default([])) | join(' ') }}
 {% endif %}
 {% if listen.retry_on is defined %}
-  retry-on {% for r in listen.retry_on %}{{ r }}{% endfor %}
-
+  retry-on {{ listen.retry_on | join (' ') }}
 {% endif %}
 {% if listen.retries is defined %}
   retries {{ listen.retries }}


### PR DESCRIPTION
This Pull Request is a little on the larger side, but in principle is quite simple. Due to ansible setting `trim_blocks` to true for jinja templating, having a block that ends a line eats the following line break, as evidenced by the blank lines that were strategically placed into the templates.

Changing from a jinja conditional block to a variable expression with filters avoids this.

The following two methods have been used - one for expected bare strings, and the other with expected lists. In both instances, where a leading space is needed to be generated, an empty string list (`['']`) is prepended to the variable (coerced into a list in the case of strings using a `ternary()` call), to then be joined using `join(' ')` to add spaces between all elements - including the first, which is now an empty string, to create the leading space.

#### Strings:
```yaml
{{ string_var is defined | ternary([''] + [string_var], []) | join(' ') }}
```

#### Lists:
Where var is required and a space is given before the opening braces:
```yaml
{{ list_var | join(' ') }}
```
Where an inital space is needed because the var is optional:
```yaml
{{ ([''] + list_var | default([])) | join(' ') }}
```
