### PR TITLE
Support configuring hash-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.bind_process`:  [optional]: Limits the declaration to a certain set of processes numbers (e.g. `[all]`, `[1]`, `[2 ,3, 4]`)
 * `haproxy_listen.{n}.mode`: [optional]: Set the running mode or protocol of the section (e.g. `http`)
 * `haproxy_listen.{n}.balance`: [required]: The load balancing algorithm to be used (e.g. `roundrobin`)
-* `haproxy_listen.{n}.hash-type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
+* `haproxy_listen.{n}.hash_type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
 * `haproxy_listen.{n}.maxconn`: [optional]: Fix the maximum number of concurrent connections
 * `haproxy_listen.{n}.source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_listen.{n}.option`: [optional]: Options to set (e.g. `[dontlog-normal]`)
@@ -302,7 +302,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_backend.{n}.stick`: [optional]: Stick declarations
 * `haproxy_backend.{n}.stick.{n}.table`: [required]: Configure the stickiness table for the current section (e.g. `type ip size 500k`)
 * `haproxy_backend.{n}.stick.{n}.stick_on`: [optional]: Define a request pattern to associate a user to a server (e.g. `src`)
-* `haproxy_backend.{n}.hash-type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
+* `haproxy_backend.{n}.hash_type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
 * `haproxy_backend.{n}.no_option`: [optional]: Options to unset (e.g. `[forceclose]`)
 * `haproxy_backend.{n}.no_log`: [optional, default `false`]: Used when the logger list must be flushed. For example, if you don't want to inherit from the default logger list
 * `haproxy_backend.{n}.tcp_check`: [optional]: Perform health checks using tcp-check send/expect sequences (e.g. `['expect string +OK\ POP3\ ready']`)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_listen.{n}.bind_process`:  [optional]: Limits the declaration to a certain set of processes numbers (e.g. `[all]`, `[1]`, `[2 ,3, 4]`)
 * `haproxy_listen.{n}.mode`: [optional]: Set the running mode or protocol of the section (e.g. `http`)
 * `haproxy_listen.{n}.balance`: [required]: The load balancing algorithm to be used (e.g. `roundrobin`)
+* `haproxy_listen.{n}.hash-type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
 * `haproxy_listen.{n}.maxconn`: [optional]: Fix the maximum number of concurrent connections
 * `haproxy_listen.{n}.source`: [optional]: Set the source address or interface for connections from the proxy
 * `haproxy_listen.{n}.option`: [optional]: Options to set (e.g. `[dontlog-normal]`)
@@ -301,6 +302,7 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_backend.{n}.stick`: [optional]: Stick declarations
 * `haproxy_backend.{n}.stick.{n}.table`: [required]: Configure the stickiness table for the current section (e.g. `type ip size 500k`)
 * `haproxy_backend.{n}.stick.{n}.stick_on`: [optional]: Define a request pattern to associate a user to a server (e.g. `src`)
+* `haproxy_backend.{n}.hash-type`: [optional]: The hashing type to be used for balancing (e.g. `consistent`)
 * `haproxy_backend.{n}.no_option`: [optional]: Options to unset (e.g. `[forceclose]`)
 * `haproxy_backend.{n}.no_log`: [optional, default `false`]: Used when the logger list must be flushed. For example, if you don't want to inherit from the default logger list
 * `haproxy_backend.{n}.tcp_check`: [optional]: Perform health checks using tcp-check send/expect sequences (e.g. `['expect string +OK\ POP3\ ready']`)

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -46,6 +46,9 @@ backend {{ backend.name }}
 {% for timeout in backend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
+{% if backend.hash-type is defined %}
+  hash-type {{ hash-type }}
+{% endif %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in backend[action] | default([]) %}
   {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -46,8 +46,8 @@ backend {{ backend.name }}
 {% for timeout in backend.timeout | default([]) %}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
-{% if backend.hash-type is defined %}
-  hash-type {{ backend.hash-type }}
+{% if backend.hash_type is defined %}
+  hash-type {{ backend.hash_type }}
 {% endif %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in backend[action] | default([]) %}

--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -47,7 +47,7 @@ backend {{ backend.name }}
   timeout {{ timeout.type }} {{ timeout.timeout }}
 {% endfor %}
 {% if backend.hash-type is defined %}
-  hash-type {{ hash-type }}
+  hash-type {{ backend.hash-type }}
 {% endif %}
 {% for action in ['reqadd', 'rspadd'] %}
 {% for params in backend[action] | default([]) %}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -16,6 +16,9 @@ listen {{ listen.name }}
 {% if listen.balance is defined %}
   balance {{ listen.balance }}
 {% endif %}
+{% if listen.hash-type is defined %}
+  hash-type {{ hash-type }}
+{% endif %}
 {% if listen.maxconn is defined %}
   maxconn {{ listen.maxconn }}
 {% endif %}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -16,8 +16,8 @@ listen {{ listen.name }}
 {% if listen.balance is defined %}
   balance {{ listen.balance }}
 {% endif %}
-{% if listen.hash-type is defined %}
-  hash-type {{ listen.hash-type }}
+{% if listen.hash_type is defined %}
+  hash-type {{ listen.hash_type }}
 {% endif %}
 {% if listen.maxconn is defined %}
   maxconn {{ listen.maxconn }}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -17,7 +17,7 @@ listen {{ listen.name }}
   balance {{ listen.balance }}
 {% endif %}
 {% if listen.hash-type is defined %}
-  hash-type {{ hash-type }}
+  hash-type {{ listen.hash-type }}
 {% endif %}
 {% if listen.maxconn is defined %}
   maxconn {{ listen.maxconn }}


### PR DESCRIPTION
Using 'hash-type consistent' is important for services that are sensitive to clients floating between backend servers.