### PR TITLE
Fix OCSP filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install yamllint ansible-lint
+        run: pip install yamllint ansible-lint[core]
 
       - name: Lint code
         run: |

--- a/templates/usr/local/bin/haproxy-letsencrypt-ocsp-deploy.j2
+++ b/templates/usr/local/bin/haproxy-letsencrypt-ocsp-deploy.j2
@@ -22,13 +22,13 @@ for path in $(ls -1d {{ haproxy_letsencrypt_ssl_src_path }}/*/); do
 
   ocspUrl="$(openssl x509 -noout -ocsp_uri -in ${path}{{ haproxy_letsencrypt_ssl_cert_name }})";
 
-  openssl ocsp -no_nonce -respout "{{ haproxy_global_crt_base }}/${prefix}-${cert}.ocsp" \
+  openssl ocsp -no_nonce -respout "{{ haproxy_global_crt_base }}/${prefix}-${cert}.pem.ocsp" \
     -issuer "${path}{{ haproxy_letsencrypt_ssl_chain_name }}" \
     -verify_other "${path}{{ haproxy_letsencrypt_ssl_chain_name }}" \
     -cert "${path}{{ haproxy_letsencrypt_ssl_cert_name }}" \
     -url "${ocspUrl}";
 
-  rm -f "{{ haproxy_global_crt_base }}/${removePrefix}-${cert}.ocsp";
+  rm -f "{{ haproxy_global_crt_base }}/${removePrefix}-${cert}.pem.ocsp";
 done
 
 {% if ansible_service_mgr == 'systemd' %}


### PR DESCRIPTION
HAProxy requires the OCSP filename to contain the full filename of the pem-file with the extension `.ocsp` as suffix.

@mevdschee has showed me how to test OCSP stapling with the following command:
```
echo quit | openssl s_client -connect example.org:443 -status
```