### PR TITLE
fixes global_raw_options being placed in peers section

### DIFF
--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -79,12 +79,12 @@
 {% for option in haproxy_global_option | default([]) %}
   {{ option }}
 {% endfor %}
+{% for line in haproxy_global_raw_options | default([]) %}
+  {{ line }}
+{% endfor %}
 {% for peers in haproxy_global_peers | default([]) %}
 peers {{ peers.name }}
 {% for peer in peers.peers | default([]) %}
   peer {{ peer.name }} {{ peer.listen }}
 {% endfor %}
-{% endfor %}
-{% for line in haproxy_global_raw_options | default([]) %}
-  {{ line }}
 {% endfor %}


### PR DESCRIPTION
The raw options need to be moved above the `peers` section, otherwise they end up in the peers section.