### PR TITLE
Allow for dynamic allocation of the haproxy config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ haproxy_install: []
 haproxy_restart_handler_state: restarted
 
 haproxy_conf_template: "etc/haproxy/haproxy.cfg.j2"
+haproxy_conf_loc: "/etc/haproxy/haproxy.cfg"
 
 # global section
 haproxy_global_log:

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -3,11 +3,11 @@
 - name: configuration | update file
   template:
     src: "{{ haproxy_conf_template }}"
-    dest: /etc/haproxy/haproxy.cfg
+    dest: "{{ haproxy_conf_loc }}"
     owner: root
     group: root
     mode: 0640
-    validate: 'haproxy -f %s -c'
+    validate: "haproxy -f %s -c {{ haproxy_conf_loc }}"
   notify: restart haproxy
   tags:
     - haproxy-configuration-update-file


### PR DESCRIPTION
Some deployments use multiple haproxy config files. This is especially
apparent when using something like dataplaneapi for haproxy. This patch
provides the ability to tell the role where to store the config file,
and which config file to manage.

Signed-off-by: David Wahlstrom <david.wahlstrom@dreamhost.com>