### PR TITLE
Don't configure deprecated nbproc directive

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,5 +1,14 @@
 # tasks file
 ---
+- name: configuration | fail
+  fail:
+    msg: "haproxy_global_nbproc is deprecated"
+  when:
+    - haproxy_version is version('2.3', '>=') and haproxy_version is version('2.5', '<')
+    - haproxy_global_nbproc > 1
+  tags:
+    - haproxy-configuration-warn-or-fail
+
 - name: configuration | update file
   template:
     src: "{{ haproxy_conf_template }}"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,10 +1,11 @@
 # tasks file
 ---
-- name: configuration | fail
+- name: configuration | warn or fail
   fail:
     msg: "haproxy_global_nbproc is deprecated"
+  ignore_errors: "{{ haproxy_version is version('2.5', '<') }}"
   when:
-    - haproxy_version is version('2.3', '>=') and haproxy_version is version('2.5', '<')
+    - haproxy_version is version('2.3', '>=')
     - haproxy_global_nbproc > 1
   tags:
     - haproxy-configuration-warn-or-fail

--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -69,7 +69,7 @@
 {% if haproxy_global_ssl_mode_async | default(false) | bool %}
   ssl-mode-async
 {% endif %}
-{% if haproxy_version < 2.3 %}
+{% if haproxy_version is version('2.5', '<') %}
   nbproc {{ haproxy_global_nbproc }}
 {% endif %}
 {% if haproxy_global_nbthread is defined %}

--- a/templates/etc/haproxy/global.cfg.j2
+++ b/templates/etc/haproxy/global.cfg.j2
@@ -69,7 +69,9 @@
 {% if haproxy_global_ssl_mode_async | default(false) | bool %}
   ssl-mode-async
 {% endif %}
+{% if haproxy_version < 2.3 %}
   nbproc {{ haproxy_global_nbproc }}
+{% endif %}
 {% if haproxy_global_nbthread is defined %}
   nbthread {{ haproxy_global_nbthread }}
 {% endif %}


### PR DESCRIPTION
This directive was depreacted in 2.3 and will be removed in 2.5. For
more information see the release notes
https://www.haproxy.com/blog/announcing-haproxy-2-3/#deprecated-and-removed-directives