### PR TITLE
Add support for haproxy caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,18 @@ Set up (the latest version of) [HAProxy](http://www.haproxy.org/) in Ubuntu syst
 * `haproxy_letsencrypt_ocsp_deploy_job.month`: [default: `*`]: Month of the year the job should run (e.g `1-12`, `*`, `*/2`)
 * `haproxy_letsencrypt_ocsp_deploy_job.weekday`: [default: `*`]: Day of the week that the job should run (e.g. `0-6` for Sunday-Saturday, `*`)
 
+* `haproxy_cache`: [default: `[]`]: Caching declarations
+* `haproxy_cache.{n}.name`: [default: [required]]: The name of the cache
+* `haproxy_cache.{n}.total_max_size`: [default: []]: Max size (in MB) of the cache
+* `haproxy_cache.{n}.max_object_size`: [default: []]: Max size (in MB) of any single object in the cache
+* `haproxy_cache.{n}.max_age`: [default: []]: Max age (in seconds) to hold an item in cache
+
+* `haproxy_program`: [default: `[]`]: Program declarations
+* `haproxy_program.{n}.name`: [default: [required]]: The name of the program
+* `haproxy_program.{n}.command`: [default: `[]`]: Command to execute
+* `haproxy_program.{n}.option`: [default: `[]`]: Options to enable
+* `haproxy_program.{n}.no_option`: [default: `[]`]: Options to inverse/disable 
+
 ## Dependencies
 
 None

--- a/templates/etc/haproxy/cache.cfg.j2
+++ b/templates/etc/haproxy/cache.cfg.j2
@@ -1,0 +1,14 @@
+{% if cache is defined %}
+{% for cache in haproxy_cache %}
+cache {{ cache.name }}
+{% if cache.total_max_size is defined %}
+  total-max-size {{ cache.total_max_size }}
+{% endif %}
+{% if cache.max_object_size is defined %}
+  max-object-size {{ cache.max_object_size }}
+{% endif %}
+{% if cache.max_age is defined %}
+  max-age {{ cache.max_age }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -10,6 +10,8 @@ defaults
 
 {% include 'resolvers.cfg.j2' %}
 
+{% include 'program.cfg.j2' %}
+
 {% include 'listen.cfg.j2' %}
 
 {% include 'cache.cfg.j2' %}

--- a/templates/etc/haproxy/haproxy.cfg.j2
+++ b/templates/etc/haproxy/haproxy.cfg.j2
@@ -12,6 +12,8 @@ defaults
 
 {% include 'listen.cfg.j2' %}
 
+{% include 'cache.cfg.j2' %}
+
 {% include 'frontend.cfg.j2' %}
 
 {% include 'backend.cfg.j2' %}

--- a/templates/etc/haproxy/program.cfg.j2
+++ b/templates/etc/haproxy/program.cfg.j2
@@ -1,0 +1,14 @@
+{% if haproxy_program is defined %}
+{% for program in haproxy_program %}
+program {{ program.name }}
+{% if program.command is defined %}
+  command {{ program.command }}
+{% endif %}
+{% for option in program.option | default([]) %}
+  option {{ option }}
+{% endfor %}
+{% for option in program.no_option | default([]) %}
+  no option {{ option }}
+{% endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This patch adds support for the "cache" section of the haproxy config
file.
https://cbonte.github.io/haproxy-dconv/2.1/configuration.html#6.2.1

Signed-off-by: David Wahlstrom <david.wahlstrom@dreamhost.com>