### PR TITLE
Make CI work again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
         include:
           - distro: ubuntu1604
             ansible-version: '>=2.9, <2.10'
+            molecule_version: "==3.0.8"
           - distro: ubuntu1604
             ansible-version: '>=2.10, <2.11'
+            molecule_version: "==3.2.4"
           - distro: ubuntu1604
           - distro: ubuntu1804
           - distro: ubuntu2004
@@ -62,7 +64,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install 'ansible${{ matrix.ansible-version }}' molecule[docker] docker
+        run: pip install 'ansible${{ matrix.ansible-version }}' 'molecule[docker]${{ matrix.molecule_version }}' docker
 
       - name: Run Molecule tests
         run: |

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 # handlers file
 ---
 - name: restart haproxy
-  service:
+  ansible.builtin.service:
     name: haproxy
     state: "{{ haproxy_restart_handler_state }}"
   when: service_default_state | default('started') == 'started'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,6 @@
   become: true
   pre_tasks:
     - name: include vars
-      include_vars: "{{ playbook_dir }}/../../tests/vars/main.yml"
+      ansible.builtin.include_vars: "{{ playbook_dir }}/../../tests/vars/main.yml"
   roles:
     - ../../../

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: acl | create directories
-  file:
+  ansible.builtin.file:
     path: "{{ item.dest | dirname }}"
     state: directory
     owner: "{{ item.owner | default('root') }}"
@@ -12,7 +12,7 @@
     - haproxy-acl-create-directories
 
 - name: acl | update files
-  template:
+  ansible.builtin.template:
     src: etc/haproxy/acl.j2
     dest: "{{ item.dest }}"
     owner: "{{ item.owner | default('root') }}"

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: certificates | create directories
-  file:
+  ansible.builtin.file:
     path: "{{ item.dest | dirname }}"
     state: directory
     owner: "{{ item.owner | default('root') }}"
@@ -13,7 +13,7 @@
     - haproxy-certificates-create-directories
 
 - name: certificates | copy files
-  copy:
+  ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: "{{ item.owner | default('root') }}"
@@ -26,7 +26,7 @@
     - haproxy-certificates-copy-files
 
 - name: certificates | remove files
-  file:
+  ansible.builtin.file:
     path: "{{ item.dest }}"
     state: absent
   with_items: "{{ haproxy_ssl_map }}"

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: configuration | warn or fail
-  fail:
+  ansible.builtin.fail:
     msg: "haproxy_global_nbproc is deprecated"
   ignore_errors: "{{ haproxy_version is version('2.5', '<') }}"
   when:
@@ -11,7 +11,7 @@
     - haproxy-configuration-warn-or-fail
 
 - name: configuration | update file
-  template:
+  ansible.builtin.template:
     src: "{{ haproxy_conf_template }}"
     dest: /etc/haproxy/haproxy.cfg
     owner: root

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: install | dependencies (pre)
-  apt:
+  ansible.builtin.apt:
     name: "{{ haproxy_dependencies_pre }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
@@ -10,7 +10,7 @@
     - haproxy-repository-install-dependencies
 
 - name: install | add repository from PPA and install its signing key
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ haproxy_ppa }}"
     update_cache: true
   when: haproxy_use_ppa | bool
@@ -18,7 +18,7 @@
     - haproxy-install-add-repository
 
 - name: install | dependencies
-  apt:
+  ansible.builtin.apt:
     name: "{{ item.name }}"
     state: "{{ item.state }}"
   with_items: "{{ haproxy_dependencies }}"
@@ -26,7 +26,7 @@
     - haproxy-install-dependencies
 
 - name: install | additional
-  apt:
+  ansible.builtin.apt:
     name: "{{ haproxy_install }}"
     state: "{{ apt_install_state | default('latest') }}"
   tags:

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: letsencrypt | copy SSL deploy script
-  template:
+  ansible.builtin.template:
     src: "{{ haproxy_letsencrypt_ssl_deploy_template }}"
     dest: "{{ haproxy_letsencrypt_ssl_deploy }}"
     owner: root
@@ -11,7 +11,7 @@
     - haproxy-letsencrypt-ssl-deploy
 
 - name: letsencrypt | copy OCSP deploy script
-  template:
+  ansible.builtin.template:
     src: "{{ haproxy_letsencrypt_ocsp_deploy_template }}"
     dest: "{{ haproxy_letsencrypt_ocsp_deploy }}"
     owner: root
@@ -21,7 +21,7 @@
     - haproxy-letsencrypt-ocsp-deploy
 
 - name: letsencrypt | configure (cron) job for OCSP deploy
-  cron:
+  ansible.builtin.cron:
     name: haproxy-letsencrypt-ocsp-deploy
     job: "{{ haproxy_letsencrypt_ocsp_deploy }}"
     state: "{{ haproxy_letsencrypt_ocsp_deploy_job.state | default('absent') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: check version support
-  fail:
+  ansible.builtin.fail:
     msg: "HAProxy version {{ haproxy_version }} is not supported"
   when: haproxy_version | string not in haproxy_versions_supported
   tags:
@@ -40,7 +40,7 @@
     - haproxy-letsencrypt
 
 - name: start and enable service
-  service:
+  ansible.builtin.service:
     name: haproxy
     state: "{{ service_default_state | default('started') }}"
     enabled: "{{ service_default_enabled | default(true) | bool }}"


### PR DESCRIPTION
Since I've used this role at my day job, I thought I'd try to contribute something back.

This PR fixes fixes the issues that cause the CI pipeline to fail. Two changes have been made:

### Fix ansible-lint errors
Use FQCN (fully qualified collection name) for all builtin actions. This is supported from ansible-core 2.9 onward, which is the minimum Ansible version for the role according to `meta/main.yml`.

### Adapt Molecule version to the tested Ansible version
The latest version of Molecule only supports ansible-core 2.12 and up. To test the role with ansible-core 2.9 and 2.10, we need to specify older versions of Molecule that support those Ansible versions.

For ansible-core 2.9 that's Molecule 3.0.8 (as 3.1.0 drops support for 2.9) and for ansible-core 2.10 that's Molecule 3.2.4 (even though Molecule up to version 3.6.1 *should* support ansible-core 2.10 according to its `setup.cfg`, the newest Molecule version I could get to actually work without errors was 3.2.4).